### PR TITLE
Refact/#1 테스트코드 작성 및 코드 개선

### DIFF
--- a/BE/apps/api-server/src/modules/auth/auth.controller.spec.ts
+++ b/BE/apps/api-server/src/modules/auth/auth.controller.spec.ts
@@ -1,20 +1,230 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { AuthController } from './auth.controller';
+import { AuthController, AuthenticatedRequest } from './auth.controller';
 import { AuthService } from './auth.service';
+import { UserService } from '../user/user.service';
+import { User } from '@app/entity';
+import { Response, Request } from 'express';
 
 describe('AuthController', () => {
   let controller: AuthController;
+  let authService: AuthService;
+  let userService: UserService;
+
+  const createMockRequest = (user: Partial<User>, cookies: any = {}) => {
+    const req = {
+      ...Object.create(Request.prototype),
+      user,
+      cookies,
+    };
+    return req as AuthenticatedRequest;
+  };
+
+  const createMockResponse = (): Response => {
+    const res = {
+      ...Object.create(Response.prototype),
+      cookie: jest.fn(),
+      redirect: jest.fn(),
+      clearCookie: jest.fn(),
+      json: jest.fn(),
+    };
+    return res;
+  };
+
+  const mockUser: Partial<User> = {
+    id: 1,
+    email: 'test@example.com',
+    name: 'Test User',
+  };
+
+  const mockAuthService = {
+    generateRefreshToken: jest.fn(),
+    verifiedRefreshToken: jest.fn(),
+    logout: jest.fn(),
+  };
+
+  const mockUserService = {
+    findByGithubEmail: jest.fn(),
+    createGithubUser: jest.fn(),
+    findByKakaoEmail: jest.fn(),
+    createKakaoUser: jest.fn(),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AuthController],
-      providers: [AuthService],
+      providers: [
+        {
+          provide: AuthService,
+          useValue: mockAuthService,
+        },
+        {
+          provide: UserService,
+          useValue: mockUserService,
+        },
+      ],
     }).compile();
 
     controller = module.get<AuthController>(AuthController);
+    authService = module.get<AuthService>(AuthService);
+    userService = module.get<UserService>(UserService);
   });
 
-  it('should be defined', () => {
-    expect(controller).toBeDefined();
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  describe('callback', () => {
+    describe('githubLoginCallback', () => {
+      it('이미 회원인 경우 쿠키에 refreshToken을 저장하고 /auth로 리다이렉트 한다.', async () => {
+        // 목 설정
+        const mockRefreshToken = 'refresh-token';
+        const mockReq = createMockRequest(mockUser);
+        const mockRes = createMockResponse();
+
+        mockUserService.findByGithubEmail.mockResolvedValue(mockUser);
+        mockAuthService.generateRefreshToken.mockReturnValue(mockRefreshToken);
+
+        // 테스트 실행
+        await controller.githubLoginCallback(mockReq, mockRes);
+
+        // 검증
+        expect(mockUserService.findByGithubEmail).toHaveBeenCalledWith(mockReq.user.email);
+        expect(mockUserService.createGithubUser).not.toHaveBeenCalled();
+        expect(mockAuthService.generateRefreshToken).toHaveBeenCalledWith(mockUser);
+        expect(mockRes.cookie).toHaveBeenCalledWith('refreshToken', mockRefreshToken, {
+          httpOnly: true,
+          secure: true,
+        });
+        expect(mockRes.redirect).toHaveBeenCalledWith('/auth');
+      });
+
+      it('회원이 아닌경우 회원가입 후 쿠키에 refreshToken을 저장하고 /auth로 리다이렉트 한다.', async () => {
+        // 목 설정
+        const mockRefreshToken = 'refresh-token';
+        const mockReq = createMockRequest(mockUser);
+        const mockRes = createMockResponse();
+
+        mockUserService.findByGithubEmail.mockResolvedValue(null);
+        mockUserService.createGithubUser.mockResolvedValue(mockUser);
+        mockAuthService.generateRefreshToken.mockReturnValue(mockRefreshToken);
+
+        // 테스트 실행
+        await controller.githubLoginCallback(mockReq, mockRes);
+
+        // 검증
+        expect(mockUserService.findByGithubEmail).toHaveBeenCalledWith(mockReq.user.email);
+        expect(mockUserService.createGithubUser).toHaveBeenCalled();
+        expect(mockAuthService.generateRefreshToken).toHaveBeenCalledWith(mockUser);
+        expect(mockRes.cookie).toHaveBeenCalledWith('refreshToken', mockRefreshToken, {
+          httpOnly: true,
+          secure: true,
+        });
+        expect(mockRes.redirect).toHaveBeenCalledWith('/auth');
+      });
+    });
+
+    describe('kakaoLoginCallback', () => {
+      it('이미 회원인 경우 쿠키에 refreshToken을 저장하고 /auth로 리다이렉트 한다.', async () => {
+        // 목 설정
+        const mockRefreshToken = 'refresh-token';
+        const mockReq = createMockRequest(mockUser);
+        const mockRes = createMockResponse();
+
+        mockUserService.findByKakaoEmail.mockResolvedValue(mockUser);
+        mockAuthService.generateRefreshToken.mockReturnValue(mockRefreshToken);
+
+        // 테스트 실행
+        await controller.kakaoLoginCallback(mockReq, mockRes);
+
+        // 검증
+        expect(mockUserService.findByKakaoEmail).toHaveBeenCalledWith(mockReq.user.email);
+        expect(mockUserService.createKakaoUser).not.toHaveBeenCalled();
+        expect(mockAuthService.generateRefreshToken).toHaveBeenCalledWith(mockUser);
+        expect(mockRes.cookie).toHaveBeenCalledWith('refreshToken', mockRefreshToken, {
+          httpOnly: true,
+          secure: true,
+        });
+        expect(mockRes.redirect).toHaveBeenCalledWith('/auth');
+      });
+
+      it('회원이 아닌경우 회원가입 후 쿠키에 refreshToken을 저장하고 /auth로 리다이렉트 한다.', async () => {
+        // 목 설정
+        const mockRefreshToken = 'refresh-token';
+        const mockReq = createMockRequest(mockUser);
+        const mockRes = createMockResponse();
+
+        mockUserService.findByKakaoEmail.mockResolvedValue(null);
+        mockUserService.createKakaoUser.mockResolvedValue(mockUser);
+        mockAuthService.generateRefreshToken.mockReturnValue(mockRefreshToken);
+
+        // 테스트 실행
+        await controller.kakaoLoginCallback(mockReq, mockRes);
+
+        // 검증
+        expect(mockUserService.findByKakaoEmail).toHaveBeenCalledWith(mockReq.user.email);
+        expect(mockUserService.createKakaoUser).toHaveBeenCalled();
+        expect(mockAuthService.generateRefreshToken).toHaveBeenCalledWith(mockUser);
+        expect(mockRes.cookie).toHaveBeenCalledWith('refreshToken', mockRefreshToken, {
+          httpOnly: true,
+          secure: true,
+        });
+        expect(mockRes.redirect).toHaveBeenCalledWith('/auth');
+      });
+    });
+  });
+
+  describe('refresh', () => {
+    it('쿠키에 저장된 refreshToken을 검증하고 새로운 accessToken을 발급한다.', async () => {
+      // 목 설정
+      const mockRefreshToken = 'refresh-token';
+      const mockAccessToken = 'access-token';
+      const mockReq = createMockRequest(mockUser, {
+        refreshToken: mockRefreshToken,
+      });
+      const mockRes = createMockResponse();
+
+      mockAuthService.verifiedRefreshToken.mockResolvedValue(mockAccessToken);
+
+      // 테스트 실행
+      await controller.refresh(mockReq, mockRes);
+
+      // 검증
+      expect(mockAuthService.verifiedRefreshToken).toHaveBeenCalledWith(mockRefreshToken);
+      expect(mockRes.json).toHaveBeenCalledWith({ accessToken: mockAccessToken });
+    });
+  });
+
+  describe('logout', () => {
+    it('쿠키에 저장된 refreshToken을 삭제하고 로그아웃 한다.', async () => {
+      // 목 설정
+      const mockRefreshToken = 'refresh-token';
+      const mockReq = createMockRequest(mockUser, {
+        refreshToken: mockRefreshToken,
+      });
+      const mockRes = createMockResponse();
+
+      // 테스트 실행
+      await controller.logout(mockReq, mockRes);
+
+      // 검증
+      expect(mockAuthService.logout).toHaveBeenCalledWith(mockRefreshToken);
+      expect(mockRes.clearCookie).toHaveBeenCalledWith('refreshToken');
+      expect(mockRes.json).toHaveBeenCalledWith({ message: 'success' });
+    });
+
+    it('쿠키에 저장된 refreshToken이 없는 경우 로그아웃 하지 않는다.', async () => {
+      // 목 설정
+      const mockReq = createMockRequest(mockUser, {
+        refreshToken: undefined,
+      });
+      const mockRes = createMockResponse();
+
+      // 테스트 실행
+      await controller.logout(mockReq, mockRes);
+
+      // 검증
+      expect(mockAuthService.logout).not.toHaveBeenCalled();
+      expect(mockRes.clearCookie).not.toHaveBeenCalled();
+      expect(mockRes.json).not.toHaveBeenCalledWith();
+    });
   });
 });

--- a/BE/apps/api-server/src/modules/auth/auth.controller.spec.ts
+++ b/BE/apps/api-server/src/modules/auth/auth.controller.spec.ts
@@ -43,10 +43,8 @@ describe('AuthController', () => {
   };
 
   const mockUserService = {
-    findByGithubEmail: jest.fn(),
-    createGithubUser: jest.fn(),
-    findByKakaoEmail: jest.fn(),
-    createKakaoUser: jest.fn(),
+    findByEmail: jest.fn(),
+    createUser: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -80,15 +78,15 @@ describe('AuthController', () => {
         const mockReq = createMockRequest(mockUser);
         const mockRes = createMockResponse();
 
-        mockUserService.findByGithubEmail.mockResolvedValue(mockUser);
+        mockUserService.findByEmail.mockResolvedValue(mockUser);
         mockAuthService.generateRefreshToken.mockReturnValue(mockRefreshToken);
 
         // 테스트 실행
         await controller.githubLoginCallback(mockReq, mockRes);
 
         // 검증
-        expect(mockUserService.findByGithubEmail).toHaveBeenCalledWith(mockReq.user.email);
-        expect(mockUserService.createGithubUser).not.toHaveBeenCalled();
+        expect(mockUserService.findByEmail).toHaveBeenCalledWith(mockReq.user.email, 'github');
+        expect(mockUserService.createUser).not.toHaveBeenCalled();
         expect(mockAuthService.generateRefreshToken).toHaveBeenCalledWith(mockUser);
         expect(mockRes.cookie).toHaveBeenCalledWith('refreshToken', mockRefreshToken, {
           httpOnly: true,
@@ -103,16 +101,16 @@ describe('AuthController', () => {
         const mockReq = createMockRequest(mockUser);
         const mockRes = createMockResponse();
 
-        mockUserService.findByGithubEmail.mockResolvedValue(null);
-        mockUserService.createGithubUser.mockResolvedValue(mockUser);
+        mockUserService.findByEmail.mockResolvedValue(null);
+        mockUserService.createUser.mockResolvedValue(mockUser);
         mockAuthService.generateRefreshToken.mockReturnValue(mockRefreshToken);
 
         // 테스트 실행
         await controller.githubLoginCallback(mockReq, mockRes);
 
         // 검증
-        expect(mockUserService.findByGithubEmail).toHaveBeenCalledWith(mockReq.user.email);
-        expect(mockUserService.createGithubUser).toHaveBeenCalled();
+        expect(mockUserService.findByEmail).toHaveBeenCalledWith(mockReq.user.email, 'github');
+        expect(mockUserService.createUser).toHaveBeenCalled();
         expect(mockAuthService.generateRefreshToken).toHaveBeenCalledWith(mockUser);
         expect(mockRes.cookie).toHaveBeenCalledWith('refreshToken', mockRefreshToken, {
           httpOnly: true,
@@ -129,15 +127,15 @@ describe('AuthController', () => {
         const mockReq = createMockRequest(mockUser);
         const mockRes = createMockResponse();
 
-        mockUserService.findByKakaoEmail.mockResolvedValue(mockUser);
+        mockUserService.findByEmail.mockResolvedValue(mockUser);
         mockAuthService.generateRefreshToken.mockReturnValue(mockRefreshToken);
 
         // 테스트 실행
         await controller.kakaoLoginCallback(mockReq, mockRes);
 
         // 검증
-        expect(mockUserService.findByKakaoEmail).toHaveBeenCalledWith(mockReq.user.email);
-        expect(mockUserService.createKakaoUser).not.toHaveBeenCalled();
+        expect(mockUserService.findByEmail).toHaveBeenCalledWith(mockReq.user.email, 'kakao');
+        expect(mockUserService.createUser).not.toHaveBeenCalled();
         expect(mockAuthService.generateRefreshToken).toHaveBeenCalledWith(mockUser);
         expect(mockRes.cookie).toHaveBeenCalledWith('refreshToken', mockRefreshToken, {
           httpOnly: true,
@@ -152,16 +150,16 @@ describe('AuthController', () => {
         const mockReq = createMockRequest(mockUser);
         const mockRes = createMockResponse();
 
-        mockUserService.findByKakaoEmail.mockResolvedValue(null);
-        mockUserService.createKakaoUser.mockResolvedValue(mockUser);
+        mockUserService.findByEmail.mockResolvedValue(null);
+        mockUserService.createUser.mockResolvedValue(mockUser);
         mockAuthService.generateRefreshToken.mockReturnValue(mockRefreshToken);
 
         // 테스트 실행
         await controller.kakaoLoginCallback(mockReq, mockRes);
 
         // 검증
-        expect(mockUserService.findByKakaoEmail).toHaveBeenCalledWith(mockReq.user.email);
-        expect(mockUserService.createKakaoUser).toHaveBeenCalled();
+        expect(mockUserService.findByEmail).toHaveBeenCalledWith(mockReq.user.email, 'kakao');
+        expect(mockUserService.createUser).toHaveBeenCalled();
         expect(mockAuthService.generateRefreshToken).toHaveBeenCalledWith(mockUser);
         expect(mockRes.cookie).toHaveBeenCalledWith('refreshToken', mockRefreshToken, {
           httpOnly: true,

--- a/BE/apps/api-server/src/modules/auth/auth.controller.ts
+++ b/BE/apps/api-server/src/modules/auth/auth.controller.ts
@@ -32,11 +32,11 @@ export class AuthController {
   @UseGuards(AuthGuard('github'))
   async githubLoginCallback(@Req() req: AuthenticatedRequest, @Res() res: Response) {
     const email = req.user.email;
-    let user = await this.userService.findByGithubEmail(email);
+    let user = await this.userService.findByEmail(email, 'github');
 
     if (!user) {
       const newUser = plainToInstance(UserCreateDto, req.user);
-      user = await this.userService.createGithubUser(newUser);
+      user = await this.userService.createUser(newUser, 'github');
     }
 
     const refreshToken = this.authService.generateRefreshToken(user);
@@ -52,11 +52,11 @@ export class AuthController {
   @UseGuards(AuthGuard('kakao'))
   async kakaoLoginCallback(@Req() req: AuthenticatedRequest, @Res() res: Response) {
     const email = req.user.email;
-    let user = await this.userService.findByKakaoEmail(email);
+    let user = await this.userService.findByEmail(email, 'kakao');
 
     if (!user) {
       const newUser = plainToInstance(UserCreateDto, req.user);
-      user = await this.userService.createKakaoUser(newUser);
+      user = await this.userService.createUser(newUser, 'kakao');
     }
 
     const refreshToken = this.authService.generateRefreshToken(user);

--- a/BE/apps/api-server/src/modules/auth/auth.controller.ts
+++ b/BE/apps/api-server/src/modules/auth/auth.controller.ts
@@ -12,6 +12,9 @@ export interface AuthenticatedRequest extends Request {
     email: string;
     name?: string;
   };
+  cookies: {
+    refreshToken?: string;
+  };
 }
 
 @Controller('auth')
@@ -43,11 +46,11 @@ export class AuthController {
 
   @Get('kakao')
   @UseGuards(AuthGuard('kakao'))
-  async googleLogin() {}
+  async kakaoLogin() {}
 
   @Get('kakao/callback')
   @UseGuards(AuthGuard('kakao'))
-  async googleLoginCallback(@Req() req: AuthenticatedRequest, @Res() res: Response) {
+  async kakaoLoginCallback(@Req() req: AuthenticatedRequest, @Res() res: Response) {
     const email = req.user.email;
     let user = await this.userService.findByKakaoEmail(email);
 
@@ -62,16 +65,16 @@ export class AuthController {
   }
 
   @Post('refresh')
-  async refresh(@Req() req: Request, @Res() res: Response) {
-    const refreshToken = req.cookies['refreshToken'];
+  async refresh(@Req() req: AuthenticatedRequest, @Res() res: Response) {
+    const refreshToken = req.cookies.refreshToken;
     const accessToken = await this.authService.verifiedRefreshToken(refreshToken);
     res.json({ accessToken });
   }
 
   @Post('logout')
-  async logout(@Req() req: Request, @Res() res: Response) {
-    const refreshToken = req.cookies['refreshToken'];
-    if (refreshToken) {
+  async logout(@Req() req: AuthenticatedRequest, @Res() res: Response) {
+    const refreshToken = req.cookies.refreshToken;
+    if (typeof refreshToken === 'string') {
       await this.authService.logout(refreshToken);
       res.clearCookie('refreshToken');
       res.json({ message: 'success' });

--- a/BE/apps/api-server/src/modules/auth/auth.service.spec.ts
+++ b/BE/apps/api-server/src/modules/auth/auth.service.spec.ts
@@ -1,18 +1,146 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthService } from './auth.service';
+import { JwtService } from '@nestjs/jwt';
+import { RedisService } from '@liaoliaots/nestjs-redis';
+import { UnauthorizedException } from '@nestjs/common';
+import { User } from '@app/entity';
+import { authException } from '../../exceptions';
 
 describe('AuthService', () => {
   let service: AuthService;
+  let jwtService: JwtService;
+  let redisService: RedisService;
+
+  const mockUser: User = {
+    id: 1,
+    email: 'test@example.com',
+    name: 'Test User',
+  } as User;
+
+  const mockJwtService = {
+    sign: jest.fn(),
+    verify: jest.fn(),
+  };
+
+  const mockRedisService = {
+    getOrThrow: jest.fn().mockReturnValue({
+      set: jest.fn(),
+      get: jest.fn(),
+    }),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AuthService],
+      providers: [
+        AuthService,
+        {
+          provide: JwtService,
+          useValue: mockJwtService,
+        },
+        {
+          provide: RedisService,
+          useValue: mockRedisService,
+        },
+      ],
     }).compile();
 
     service = module.get<AuthService>(AuthService);
+    jwtService = module.get<JwtService>(JwtService);
+    redisService = module.get<RedisService>(RedisService);
   });
 
-  it('should be defined', () => {
+  it('서비스가 정의되어 있어야 한다', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('generateAccessToken', () => {
+    it('access token을 생성해야 한다', () => {
+      const mockToken = 'mock.access.token';
+      mockJwtService.sign.mockReturnValue(mockToken);
+
+      const result = service.generateAccessToken(mockUser);
+
+      expect(result).toBe(mockToken);
+      expect(mockJwtService.sign).toHaveBeenCalledWith({ email: 'test@example.com', id: 1 }, { expiresIn: 60 * 30 });
+    });
+  });
+
+  describe('generateRefreshToken', () => {
+    it('refresh token을 생성해야 한다', () => {
+      const mockToken = 'mock.refresh.token';
+      mockJwtService.sign.mockReturnValue(mockToken);
+
+      const result = service.generateRefreshToken(mockUser);
+
+      expect(result).toBe(mockToken);
+      expect(mockJwtService.sign).toHaveBeenCalledWith(
+        { id: mockUser.id, email: mockUser.email },
+        { expiresIn: '14d' },
+      );
+    });
+  });
+
+  describe('verifiedRefreshToken', () => {
+    const mockRefreshToken = 'mock.refresh.token';
+    const mockAccessToken = 'mock.access.token';
+
+    it('refresh token을 검증하고 새로운 access token을 반환해야 한다', async () => {
+      const mockPayload = { id: mockUser.id, email: mockUser.email };
+      mockJwtService.verify.mockReturnValue(mockPayload);
+      mockJwtService.sign.mockReturnValue(mockAccessToken);
+
+      const result = await service.verifiedRefreshToken(mockRefreshToken);
+
+      expect(result).toBe(mockAccessToken);
+      expect(mockJwtService.verify).toHaveBeenCalledWith(mockRefreshToken);
+      expect(mockJwtService.sign).toHaveBeenCalledWith(
+        { email: mockUser.email, id: mockUser.id },
+        { expiresIn: 60 * 30 },
+      );
+    });
+
+    it('토큰이 유효하지 않을 때 authException을 발생시켜야 한다', async () => {
+      mockJwtService.verify.mockImplementation(() => {
+        throw new Error('Invalid token');
+      });
+
+      await expect(service.verifiedRefreshToken(mockRefreshToken)).rejects.toThrow(authException);
+    });
+  });
+
+  describe('logout', () => {
+    const mockRefreshToken = 'mock.refresh.token';
+
+    it('refresh token을 블랙리스트에 추가해야 한다', async () => {
+      const mockRedis = mockRedisService.getOrThrow();
+      await service.logout(mockRefreshToken);
+
+      expect(mockRedis.set).toHaveBeenCalledWith(mockRefreshToken, 'true', 'EX', 60 * 60 * 24 * 3);
+    });
+
+    it('로그아웃이 실패할 때 authException을 발생시켜야 한다', async () => {
+      const mockRedis = mockRedisService.getOrThrow();
+      mockRedis.set.mockRejectedValue(new Error('Redis error'));
+
+      await expect(service.logout(mockRefreshToken)).rejects.toThrow(authException);
+    });
+  });
+
+  describe('checkBlackList', () => {
+    const mockRefreshToken = 'mock.refresh.token';
+
+    it('토큰이 블랙리스트에 있을 때 UnauthorizedException을 발생시켜야 한다', async () => {
+      const mockRedis = mockRedisService.getOrThrow();
+      mockRedis.get.mockResolvedValue('true');
+
+      await expect(service['checkBlackList'](mockRefreshToken)).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('토큰이 블랙리스트에 없을 때 예외를 발생시키지 않아야 한다', async () => {
+      const mockRedis = mockRedisService.getOrThrow();
+      mockRedis.get.mockResolvedValue(null);
+
+      await expect(service['checkBlackList'](mockRefreshToken)).resolves.not.toThrow();
+    });
   });
 });

--- a/BE/apps/api-server/src/modules/auth/auth.service.ts
+++ b/BE/apps/api-server/src/modules/auth/auth.service.ts
@@ -1,14 +1,10 @@
 import { RedisService } from '@liaoliaots/nestjs-redis';
-import { BadRequestException, Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { User } from '@app/entity';
 import Redis from 'ioredis';
 import { authException } from '../../exceptions';
-
-interface tokenPayload {
-  email: string;
-  id: number;
-}
+import { JwtPayload, RefreshTokenPayload } from '@app/jwt';
 
 @Injectable()
 export class AuthService {
@@ -22,36 +18,23 @@ export class AuthService {
   }
 
   generateAccessToken(user: User) {
-    const payload = { email: user.email, id: user.id };
+    const payload: JwtPayload = { email: user.email, id: user.id };
     const accessToken = this.jwtService.sign(payload, { expiresIn: 60 * 30 });
     return accessToken;
   }
 
   generateRefreshToken(user: User) {
-    const payload = { id: user.id, email: user.email };
+    const payload: RefreshTokenPayload = { id: user.id, email: user.email };
     const refreshToken = this.jwtService.sign(payload, { expiresIn: '14d' });
     return refreshToken;
   }
 
   async verifiedRefreshToken(refreshToken: string) {
     try {
-      const isBlacklisted = await this.GeneralRedis.get(refreshToken);
-      if (isBlacklisted === 'true') {
-        throw new UnauthorizedException('다시 로그인해주세요.');
-      }
-      this.jwtService.verify(refreshToken);
-      const decoded = this.jwtService.decode(refreshToken);
-      if (!decoded || typeof decoded !== 'object') {
-        throw new BadRequestException('유효하지 않은 토큰입니다.');
-      }
-
-      const payload: tokenPayload = {
-        email: decoded.email,
-        id: decoded.id,
-      };
-
-      const accessToken = this.jwtService.sign(payload, { expiresIn: 60 * 30 });
-      return accessToken;
+      await this.checkBlackList(refreshToken);
+      const refreshPayload: RefreshTokenPayload = this.jwtService.verify<RefreshTokenPayload>(refreshToken);
+      const accessPayload: JwtPayload = { email: refreshPayload.email, id: refreshPayload.id };
+      return this.jwtService.sign(accessPayload, { expiresIn: 60 * 30 });
     } catch (error) {
       this.logger.error(error);
       throw new authException('다시 로그인해주세요.');
@@ -64,6 +47,13 @@ export class AuthService {
     } catch (error) {
       this.logger.error(error);
       throw new authException('로그아웃에 실패했습니다.');
+    }
+  }
+
+  private async checkBlackList(refreshToken: string) {
+    const isBlacklisted = await this.GeneralRedis.get(refreshToken);
+    if (isBlacklisted === 'true') {
+      throw new UnauthorizedException('다시 로그인해주세요.');
     }
   }
 }

--- a/BE/apps/api-server/src/modules/connection/connection.controller.ts
+++ b/BE/apps/api-server/src/modules/connection/connection.controller.ts
@@ -26,8 +26,6 @@ export class ConnectionController {
   @UseGuards(AuthGuard('jwt'))
   async getConnection(@Query() queryDto: ConnectionQueryDto, @User() user: UserDto) {
     const { type, id } = queryDto;
-    console.log('type:', type);
-    console.log('id:', id);
     switch (type) {
       case 'connection':
         return await this.connectionService.getConnection(id as string, user.id);

--- a/BE/apps/api-server/src/modules/connection/connection.service.ts
+++ b/BE/apps/api-server/src/modules/connection/connection.service.ts
@@ -44,7 +44,7 @@ export class ConnectionService {
   async setConnection(mindmapId: number, userId: number) {
     const role = await this.userService.getRole(userId, mindmapId);
     this.logger.log(`role: ${role}`);
-    if (role === undefined) {
+    if (!role) {
       throw new ForbiddenException('권한이 없습니다.');
     }
 

--- a/BE/apps/api-server/src/modules/mindmap/mindmap.service.ts
+++ b/BE/apps/api-server/src/modules/mindmap/mindmap.service.ts
@@ -97,7 +97,7 @@ export class MindmapService {
 
   async getDataByMindmapId(mindmapId: number) {
     const mindmap = await this.mindmapRepository.findOne({ where: { id: mindmapId } });
-    const nodes = await this.nodeService.tableToCanvas(mindmap.id);
+    const nodes = await this.nodeService.getNodeTreeObject(mindmap.id);
 
     if (!mindmap) {
       throw new NotFoundException('마인드맵을 찾을 수 없습니다.');

--- a/BE/apps/api-server/src/modules/node/node.service.spec.ts
+++ b/BE/apps/api-server/src/modules/node/node.service.spec.ts
@@ -1,12 +1,29 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { NodeService } from './node.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Node } from '@app/entity';
+import { In } from 'typeorm';
 
 describe('NodeService', () => {
   let service: NodeService;
 
+  const mockNodeRepository = {
+    find: jest.fn(),
+    findDescendants: jest.fn(),
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    findBy: jest.fn(),
+    softRemove: jest.fn(),
+    update: jest.fn(),
+    manager: {
+      transaction: jest.fn(),
+    },
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [NodeService],
+      providers: [NodeService, { provide: getRepositoryToken(Node), useValue: mockNodeRepository }],
     }).compile();
 
     service = module.get<NodeService>(NodeService);
@@ -14,5 +31,557 @@ describe('NodeService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('findKeywordByMindmapId', () => {
+    const mockMindmapId = 1;
+
+    it('mindmapId에 해당하는 모든 노드의 키워드를 배열로 반환해야 한다', async () => {
+      const mockNodes = [
+        { id: 1, keyword: 'node1', mindmapId: mockMindmapId },
+        { id: 2, keyword: 'node2', mindmapId: mockMindmapId },
+        { id: 3, keyword: 'node3', mindmapId: mockMindmapId },
+      ];
+
+      mockNodeRepository.find.mockResolvedValue(mockNodes);
+
+      const result = await service.findKeywordByMindmapId(mockMindmapId);
+
+      expect(result).toEqual(['node1', 'node2', 'node3']);
+    });
+
+    it('mindmapId에 해당하는 노드가 없으면 빈 배열을 반환해야 한다', async () => {
+      mockNodeRepository.find.mockResolvedValue([]);
+
+      const result = await service.findKeywordByMindmapId(mockMindmapId);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getNodeTreeObject', () => {
+    const mockMindmapId = 1;
+
+    it('루트 노드가 없을 경우 빈 객체를 반환해야 한다', async () => {
+      mockNodeRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.getNodeTreeObject(mockMindmapId);
+
+      expect(result).toEqual({});
+      expect(mockNodeRepository.findOne).toHaveBeenCalledWith({
+        where: { mindmap: { id: mockMindmapId }, depth: 1 },
+      });
+      expect(mockNodeRepository.findDescendants).not.toHaveBeenCalled();
+    });
+
+    it('마인드맵의 모든 노드를 캔버스 형식으로 변환해야 한다', async () => {
+      // 루트 노드 Mock
+      const mockRootNode = {
+        id: 1,
+        keyword: '루트',
+        depth: 1,
+        locationX: 100,
+        locationY: 100,
+      };
+
+      // 전체 트리 구조 Mock
+      const mockNodeTree = [
+        {
+          id: 1,
+          keyword: '루트',
+          depth: 1,
+          locationX: 100,
+          locationY: 100,
+          children: [
+            {
+              id: 2,
+              keyword: '자식1',
+              depth: 2,
+              locationX: 200,
+              locationY: 50,
+            },
+            {
+              id: 3,
+              keyword: '자식2',
+              depth: 2,
+              locationX: 200,
+              locationY: 150,
+            },
+          ],
+        },
+        {
+          id: 2,
+          keyword: '자식1',
+          depth: 2,
+          locationX: 200,
+          locationY: 50,
+          children: [
+            {
+              id: 4,
+              keyword: '손자1',
+              depth: 3,
+              locationX: 300,
+              locationY: 50,
+            },
+          ],
+        },
+        {
+          id: 3,
+          keyword: '자식2',
+          depth: 2,
+          locationX: 200,
+          locationY: 150,
+          children: [],
+        },
+        {
+          id: 4,
+          keyword: '손자1',
+          depth: 3,
+          locationX: 300,
+          locationY: 50,
+          children: [],
+        },
+      ];
+
+      // Mock 설정
+      mockNodeRepository.findOne.mockResolvedValue(mockRootNode);
+      mockNodeRepository.findDescendants.mockResolvedValue(mockNodeTree);
+
+      const expectedResult = {
+        1: {
+          id: 1,
+          keyword: '루트',
+          depth: 1,
+          location: { x: 100, y: 100 },
+          children: [2, 3],
+        },
+        2: {
+          id: 2,
+          keyword: '자식1',
+          depth: 2,
+          location: { x: 200, y: 50 },
+          children: [4],
+        },
+        3: {
+          id: 3,
+          keyword: '자식2',
+          depth: 2,
+          location: { x: 200, y: 150 },
+          children: [],
+        },
+        4: {
+          id: 4,
+          keyword: '손자1',
+          depth: 3,
+          location: { x: 300, y: 50 },
+          children: [],
+        },
+      };
+
+      const result = await service.getNodeTreeObject(mockMindmapId);
+
+      expect(result).toEqual(expectedResult);
+      expect(mockNodeRepository.findOne).toHaveBeenCalledWith({
+        where: { mindmap: { id: mockMindmapId }, depth: 1 },
+      });
+      expect(mockNodeRepository.findDescendants).toHaveBeenCalledWith(mockRootNode, { relations: ['children'] });
+    });
+
+    it('단일 노드만 있는 경우를 처리해야 한다', async () => {
+      const mockSingleNode = {
+        id: 1,
+        keyword: '단일노드',
+        depth: 1,
+        locationX: 100,
+        locationY: 100,
+        children: [],
+      };
+
+      mockNodeRepository.findOne.mockResolvedValue(mockSingleNode);
+      mockNodeRepository.findDescendants.mockResolvedValue([mockSingleNode]);
+
+      const expectedResult = {
+        1: {
+          id: 1,
+          keyword: '단일노드',
+          depth: 1,
+          location: { x: 100, y: 100 },
+          children: [],
+        },
+      };
+
+      const result = await service.getNodeTreeObject(mockMindmapId);
+
+      expect(result).toEqual(expectedResult);
+    });
+  });
+
+  describe('updateNodeTree', () => {
+    const mockMindmapId = 1;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('노드 삭제와 업데이트를 모두 수행해야 한다', async () => {
+      // 현재 DB의 노드들
+      const mockCurrentNodes = [
+        { id: 1, keyword: '기존루트' },
+        { id: 2, keyword: '삭제될노드' },
+      ];
+
+      // 캔버스에서 전달된 데이터
+      const mockCanvasData = {
+        1: {
+          id: 1,
+          keyword: '수정된루트',
+          depth: 1,
+          location: { x: 100, y: 100 },
+          children: [],
+        },
+      };
+
+      // Mock 설정
+      mockNodeRepository.find.mockResolvedValue(mockCurrentNodes);
+      mockNodeRepository.manager = {
+        transaction: jest.fn((callback) =>
+          callback({
+            softRemove: jest.fn(),
+            update: jest.fn(),
+          }),
+        ),
+      };
+
+      await service.updateNodeTree(mockCanvasData, mockMindmapId);
+
+      // 트랜잭션 내에서의 동작 확인
+      const transactionCallback = mockNodeRepository.manager.transaction.mock.calls[0][0];
+      const mockEntityManager = {
+        softRemove: jest.fn(),
+        update: jest.fn(),
+      };
+      await transactionCallback(mockEntityManager);
+
+      // 삭제 동작 확인
+      expect(mockEntityManager.softRemove).toHaveBeenCalledWith(Node, [{ id: 2 }]);
+
+      // 업데이트 동작 확인
+      expect(mockEntityManager.update).toHaveBeenCalledWith(Node, 1, {
+        id: 1,
+        keyword: '수정된루트',
+        locationX: 100,
+        locationY: 100,
+        depth: 1,
+      });
+    });
+
+    it('노드 업데이트만 수행해야 한다', async () => {
+      // 현재 DB의 노드들
+      const mockCurrentNodes = [{ id: 1, keyword: '기존루트' }];
+
+      // 캔버스에서 전달된 데이터
+      const mockCanvasData = {
+        1: {
+          id: 1,
+          keyword: '수정된루트',
+          depth: 1,
+          location: { x: 100, y: 100 },
+          children: [],
+        },
+      };
+
+      // Mock 설정
+      mockNodeRepository.find.mockResolvedValue(mockCurrentNodes);
+      mockNodeRepository.manager = {
+        transaction: jest.fn((callback) =>
+          callback({
+            softRemove: jest.fn(),
+            update: jest.fn(),
+          }),
+        ),
+      };
+
+      await service.updateNodeTree(mockCanvasData, mockMindmapId);
+
+      // 현재 노드 조회 확인
+      expect(mockNodeRepository.find).toHaveBeenCalledWith({
+        where: { mindmap: { id: mockMindmapId } },
+        select: ['id'],
+      });
+
+      // 트랜잭션 내에서 update 호출 확인
+      const transactionCallback = mockNodeRepository.manager.transaction.mock.calls[0][0];
+      const mockEntityManager = {
+        softRemove: jest.fn(),
+        update: jest.fn(),
+      };
+      await transactionCallback(mockEntityManager);
+
+      expect(mockEntityManager.softRemove).not.toHaveBeenCalled();
+      expect(mockEntityManager.update).toHaveBeenCalledWith(Node, 1, {
+        id: 1,
+        keyword: '수정된루트',
+        locationX: 100,
+        locationY: 100,
+        depth: 1,
+      });
+    });
+
+    it('빈 캔버스 데이터가 전달되면 모든 노드를 삭제해야 한다', async () => {
+      // 현재 DB의 노드들
+      const mockCurrentNodes = [
+        { id: 1, keyword: '삭제될노드1' },
+        { id: 2, keyword: '삭제될노드2' },
+      ];
+
+      // Mock 설정
+      mockNodeRepository.find.mockResolvedValue(mockCurrentNodes);
+      mockNodeRepository.manager = {
+        transaction: jest.fn((callback) =>
+          callback({
+            softRemove: jest.fn(),
+            update: jest.fn(),
+          }),
+        ),
+      };
+
+      await service.updateNodeTree({}, mockMindmapId);
+
+      // 트랜잭션 내에서의 동작 확인
+      const transactionCallback = mockNodeRepository.manager.transaction.mock.calls[0][0];
+      const mockEntityManager = {
+        softRemove: jest.fn(),
+        update: jest.fn(),
+      };
+      await transactionCallback(mockEntityManager);
+
+      // 모든 노드 삭제 확인
+      expect(mockEntityManager.softRemove).toHaveBeenCalledWith(Node, [{ id: 1 }, { id: 2 }]);
+      expect(mockEntityManager.update).not.toHaveBeenCalled();
+    });
+
+    it('에러가 발생하면 로그를 남겨야 한다', async () => {
+      const mockError = new Error('데이터베이스 에러');
+      mockNodeRepository.find.mockRejectedValue(mockError);
+
+      const mockLogger = jest.spyOn(service['logger'], 'error');
+
+      await service.updateNodeTree({}, mockMindmapId);
+
+      expect(mockLogger).toHaveBeenCalledWith('노드 트리 업데이트 중 오류가 발생했습니다: 데이터베이스 에러');
+    });
+  });
+
+  describe('aiCreateNode', () => {
+    const mockMindmapId = 1;
+
+    const mockRootNode = {
+      id: 1,
+      keyword: '루트',
+      depth: 1,
+      locationX: 100,
+      locationY: 100,
+      parent: null,
+      mindmap: { id: mockMindmapId },
+      children: [],
+    };
+    const mockChildNode1 = {
+      id: 2,
+      keyword: '자식1',
+      depth: 2,
+      locationX: 200,
+      locationY: 50,
+      parent: { id: 1 },
+      mindmap: { id: mockMindmapId },
+      children: [],
+    };
+    const mockChildNode2 = {
+      id: 3,
+      keyword: '자식2',
+      depth: 2,
+      locationX: 200,
+      locationY: 150,
+      parent: { id: 1 },
+      mindmap: { id: mockMindmapId },
+      children: [],
+    };
+    const mockGrandChildNode1 = {
+      id: 4,
+      keyword: '손자1',
+      depth: 3,
+      locationX: 300,
+      locationY: 50,
+      parent: { id: 2 },
+      mindmap: { id: mockMindmapId },
+      children: [],
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('aiResponse에 따라 노드를 저장하고, getNodeTreeObject를 호출하여 최종 결과를 반환해야 한다 (루트 없는 경우)', async () => {
+      const mockAiResponse = {
+        keyword: '루트',
+        children: [
+          { keyword: '자식1', children: [{ keyword: '손자1', children: [] }] },
+          { keyword: '자식2', children: [] },
+        ],
+      };
+
+      // --- Mock Setup ---
+      // 1. findRootNode (처음에는 없음)
+      mockNodeRepository.findOne.mockResolvedValueOnce(null);
+      // 2. save (루트, 자식1, 자식2 생성)
+      mockNodeRepository.save
+        .mockResolvedValueOnce({ ...mockRootNode })
+        .mockResolvedValueOnce({ ...mockChildNode1 })
+        .mockResolvedValueOnce({ ...mockChildNode2 })
+        .mockResolvedValueOnce({ ...mockGrandChildNode1 });
+      // 3. getNodeTreeObject 호출 시 내부 동작 Mock
+      // 3.1 findRootNode (생성된 루트 반환)
+      mockNodeRepository.findOne.mockResolvedValueOnce({ ...mockRootNode });
+      // 3.2 findDescendants (생성된 노드 트리 반환 - children 관계 포함)
+      const mockCreatedTree = [
+        { ...mockRootNode, children: [mockChildNode1, mockChildNode2] }, // findDescendants는 children 로드
+        { ...mockChildNode1, children: [mockGrandChildNode1] },
+        { ...mockChildNode2, children: [] },
+        { ...mockGrandChildNode1, children: [] },
+      ];
+      mockNodeRepository.findDescendants.mockResolvedValue(mockCreatedTree);
+      // --- End Mock Setup ---
+
+      const result = await service.aiCreateNode(mockAiResponse, mockMindmapId);
+
+      // --- Assertions ---
+      // findRootNode 호출 확인 (루트 생성 시도 1번, getNodeTreeObject 내부 1번)
+      expect(mockNodeRepository.findOne).toHaveBeenCalledTimes(2);
+      expect(mockNodeRepository.findOne).toHaveBeenNthCalledWith(1, {
+        where: { mindmap: { id: mockMindmapId }, depth: 1 },
+      });
+      expect(mockNodeRepository.findOne).toHaveBeenNthCalledWith(2, {
+        where: { mindmap: { id: mockMindmapId }, depth: 1 },
+      });
+      // save 호출 확인 (루트, 자식1, 자식2)
+      expect(mockNodeRepository.save).toHaveBeenCalledTimes(4);
+      expect(mockNodeRepository.save).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ keyword: '루트', depth: 1 }),
+      );
+      expect(mockNodeRepository.save).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ keyword: '자식1', depth: 2, parent: { id: 1 } }),
+      );
+      expect(mockNodeRepository.save).toHaveBeenNthCalledWith(
+        3,
+        expect.objectContaining({ keyword: '자식2', depth: 2, parent: { id: 1 } }),
+      );
+      expect(mockNodeRepository.save).toHaveBeenNthCalledWith(
+        4,
+        expect.objectContaining({ keyword: '손자1', depth: 3, parent: { id: 2 } }),
+      );
+      // findDescendants 호출 확인 (getNodeTreeObject 내부)
+      expect(mockNodeRepository.findDescendants).toHaveBeenCalledTimes(1);
+      expect(mockNodeRepository.findDescendants).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }), {
+        relations: ['children'],
+      });
+      // 최종 결과 확인 (getNodeTreeObject의 변환 결과)
+      expect(result).toEqual({
+        1: { id: 1, keyword: '루트', depth: 1, location: { x: 100, y: 100 }, children: [2, 3] },
+        2: { id: 2, keyword: '자식1', depth: 2, location: { x: 200, y: 50 }, children: [4] },
+        3: { id: 3, keyword: '자식2', depth: 2, location: { x: 200, y: 150 }, children: [] },
+        4: { id: 4, keyword: '손자1', depth: 3, location: { x: 300, y: 50 }, children: [] },
+      });
+      // --- End Assertions ---
+    });
+
+    it('기존 루트 노드를 업데이트하고 새 자식을 저장한 후, getNodeTreeObject를 호출하여 최종 결과를 반환해야 한다', async () => {
+      const mockAiResponse = {
+        keyword: '수정된루트',
+        children: [{ keyword: '새자식', children: [] }],
+      };
+      const mockExistingRoot = { ...mockRootNode, keyword: '기존루트', children: [] }; // 기존 루트
+      const mockUpdatedRoot = { ...mockRootNode, keyword: '수정된루트' }; // 업데이트될 루트
+      const mockNewChild = { ...mockChildNode1, id: 4, keyword: '새자식' }; // 새로 생성될 자식
+
+      // --- Mock Setup ---
+      // 1. findRootNode (기존 루트 반환)
+      mockNodeRepository.findOne.mockResolvedValueOnce(mockExistingRoot);
+      // 2. save (루트 업데이트, 새 자식 생성)
+      mockNodeRepository.save.mockResolvedValueOnce({ ...mockUpdatedRoot }).mockResolvedValueOnce({ ...mockNewChild });
+      // 3. getNodeTreeObject 호출 시 내부 동작 Mock
+      // 3.1 findRootNode (업데이트된 루트 반환)
+      mockNodeRepository.findOne.mockResolvedValueOnce({ ...mockUpdatedRoot });
+      // 3.2 findDescendants (업데이트된 노드 트리 반환)
+      const mockUpdatedTree = [
+        { ...mockUpdatedRoot, children: [mockNewChild] }, // findDescendants는 children 로드
+        { ...mockNewChild, children: [] },
+      ];
+      mockNodeRepository.findDescendants.mockResolvedValue(mockUpdatedTree);
+      // --- End Mock Setup ---
+
+      const result = await service.aiCreateNode(mockAiResponse, mockMindmapId);
+
+      // --- Assertions ---
+      expect(mockNodeRepository.findOne).toHaveBeenCalledTimes(2);
+      expect(mockNodeRepository.save).toHaveBeenCalledTimes(2);
+      expect(mockNodeRepository.save).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ id: 1, keyword: '수정된루트' }),
+      );
+      expect(mockNodeRepository.save).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ keyword: '새자식', depth: 2, parent: { id: 1 } }),
+      );
+      expect(mockNodeRepository.findDescendants).toHaveBeenCalledTimes(1);
+      expect(mockNodeRepository.findDescendants).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }), {
+        relations: ['children'],
+      });
+      expect(result).toEqual({
+        1: { id: 1, keyword: '수정된루트', depth: 1, location: { x: 100, y: 100 }, children: [4] },
+        4: { id: 4, keyword: '새자식', depth: 2, location: { x: 200, y: 50 }, children: [] },
+      });
+      // --- End Assertions ---
+    });
+
+    it('여러 깊이의 노드를 저장하고 getNodeTreeObject를 호출하여 최종 결과를 반환해야 한다', async () => {
+      const mockAiResponse = {
+        keyword: '루트',
+        children: [{ keyword: '자식1', children: [{ keyword: '손자1', children: [] }] }],
+      };
+
+      // --- Mock Setup ---
+      mockNodeRepository.findOne.mockResolvedValueOnce(null); // 루트 없음
+      mockNodeRepository.save
+        .mockResolvedValueOnce({ ...mockRootNode })
+        .mockResolvedValueOnce({ ...mockChildNode1 })
+        .mockResolvedValueOnce({ ...mockGrandChildNode1 });
+
+      // getNodeTreeObject 내부 Mock
+      mockNodeRepository.findOne.mockResolvedValueOnce({ ...mockRootNode });
+      const mockCreatedTree = [
+        { ...mockRootNode, children: [mockChildNode1] },
+        { ...mockChildNode1, children: [mockGrandChildNode1] },
+        { ...mockGrandChildNode1, children: [] },
+      ];
+      mockNodeRepository.findDescendants.mockResolvedValue(mockCreatedTree);
+      // --- End Mock Setup ---
+
+      const result = await service.aiCreateNode(mockAiResponse, mockMindmapId);
+
+      // --- Assertions ---
+      expect(mockNodeRepository.findOne).toHaveBeenCalledTimes(2);
+      expect(mockNodeRepository.save).toHaveBeenCalledTimes(3);
+      expect(mockNodeRepository.findDescendants).toHaveBeenCalledTimes(1);
+      expect(mockNodeRepository.findDescendants).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }), {
+        relations: ['children'],
+      });
+      expect(result).toEqual({
+        1: { id: 1, keyword: '루트', depth: 1, location: { x: 100, y: 100 }, children: [2] },
+        2: { id: 2, keyword: '자식1', depth: 2, location: { x: 200, y: 50 }, children: [4] },
+        4: { id: 4, keyword: '손자1', depth: 3, location: { x: 300, y: 50 }, children: [] },
+      });
+      // --- End Assertions ---
+    });
   });
 });

--- a/BE/apps/api-server/src/modules/node/node.service.spec.ts
+++ b/BE/apps/api-server/src/modules/node/node.service.spec.ts
@@ -2,7 +2,6 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { NodeService } from './node.service';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Node } from '@app/entity';
-import { In } from 'typeorm';
 
 describe('NodeService', () => {
   let service: NodeService;

--- a/BE/apps/api-server/src/modules/node/node.service.ts
+++ b/BE/apps/api-server/src/modules/node/node.service.ts
@@ -102,89 +102,59 @@ export class NodeService {
     return this.nodeRepository.findOne({ where: { mindmap: { id: mindmapId }, depth: ROOT_DEPTH } });
   }
 
-  async deleteNodes(deleteNodeId: number[] | number) {
-    if (Array.isArray(deleteNodeId)) {
-      const nodesToDelete = await this.nodeRepository.findBy({ id: In(deleteNodeId) });
-      await this.nodeRepository.softRemove(nodesToDelete);
-      return;
-    }
-
-    const nodeToDelete = await this.nodeRepository.findOne({ where: { id: deleteNodeId } });
-    if (nodeToDelete) {
-      await this.nodeRepository.softRemove(nodeToDelete);
+  async aiCreateNode(aiResponse: TextAiResponse, mindmapId: number, depth = ROOT_DEPTH): Promise<NodeTreeObject> {
+    try {
+      await this.createNodeTreeRecursively(aiResponse, mindmapId, depth);
+      return this.getNodeTreeObject(mindmapId);
+    } catch (error) {
+      const message = `마인드맵 ${mindmapId}의 AI 노드 트리 생성 중 오류가 발생했습니다`;
+      this.logger.error(message, error);
+      throw error;
     }
   }
 
-  async updateNode(updateData: UpdateNodeDto | UpdateNodeDto[]) {
-    if (Array.isArray(updateData)) {
-      await Promise.all(updateData.map((data) => this.nodeRepository.update(data.id, data)));
-      return;
-    }
-    await this.nodeRepository.update(updateData.id, updateData);
+  private async createNodeTreeRecursively(
+    response: TextAiResponse,
+    mindmapId: number,
+    currentDepth: number,
+    parentNode?: Node,
+  ) {
+    const node =
+      currentDepth === ROOT_DEPTH
+        ? await this.updateOrCreateRootNode(response, mindmapId)
+        : await this.createChildNode(parentNode, response, currentDepth, mindmapId);
+
+    await Promise.all(
+      response.children.map((child) => this.createNodeTreeRecursively(child, mindmapId, currentDepth + 1, node)),
+    );
   }
 
-  async aiCreateNode(aiResponse: TextAiResponse, mindmapId: number, depth = 1) {
-    const createdNodes: Node[] = [];
+  private async updateOrCreateRootNode(aiResponse: TextAiResponse, mindmapId: number) {
+    const existingRoot = await this.findRootNode(mindmapId);
 
-    const processNode = async (
-      response: TextAiResponse,
-      currentDepth: number,
-      parentNodeId?: number,
-    ): Promise<void> => {
-      let node: Node;
-
-      if (currentDepth === 1) {
-        node = await this.nodeRepository.findOne({
-          where: { mindmap: { id: mindmapId }, depth: 1 },
-        });
-
-        if (node) {
-          node.keyword = response.keyword;
-          node = await this.nodeRepository.save(node);
+    if (existingRoot) {
+      existingRoot.keyword = aiResponse.keyword;
+      return this.nodeRepository.save(existingRoot);
         }
-      }
 
-      if (!node) {
-        node = await this.nodeRepository.save({
-          keyword: response.keyword,
-          depth: currentDepth,
-          parent: parentNodeId ? { id: parentNodeId } : null,
+    return this.nodeRepository.save({
+      keyword: aiResponse.keyword,
+      depth: ROOT_DEPTH,
           mindmap: { id: mindmapId },
         });
       }
 
-      createdNodes.push(node);
-
-      for (const child of response.children) {
-        await processNode(child, currentDepth + 1, node.id);
-      }
-    };
-
-    await processNode(aiResponse, depth);
-
-    const nodeData = {};
-
-    createdNodes.forEach((node) => {
-      const id = node.id;
-      nodeData[id] = {
-        id,
-        keyword: node.keyword,
-        depth: node.depth,
-        location: { x: node.locationX, y: node.locationY },
-        children: [],
-      };
+  private async createChildNode(
+    parentNode: Node,
+    childResponse: TextAiResponse,
+    depth: number,
+    mindmapId: number,
+  ): Promise<Node> {
+    return this.nodeRepository.save({
+      keyword: childResponse.keyword,
+      depth,
+      parent: { id: parentNode.id },
+      mindmap: { id: mindmapId },
     });
-
-    createdNodes.forEach((node) => {
-      const id = node.id;
-      if (node.parent && node.parent.id !== undefined) {
-        const parentId = node.parent.id;
-        if (nodeData[parentId]) {
-          nodeData[parentId].children.push(id);
-        }
-      }
-    });
-
-    return nodeData;
   }
 }

--- a/BE/apps/api-server/src/modules/node/node.service.ts
+++ b/BE/apps/api-server/src/modules/node/node.service.ts
@@ -41,20 +41,61 @@ export class NodeService {
     };
   }
 
-  async canvasToTable(canvasData: Record<number, NodeDto>, mindmapId: number) {
-    const dbNodes = await this.nodeRepository.find({ where: { mindmap: { id: mindmapId } } });
-    const dbNodeIds = dbNodes.map((node) => node.id);
-    const canvasNodeIds = Object.keys(canvasData).map(Number);
-    const deleteNodeIds = dbNodeIds.filter((id) => !canvasNodeIds.includes(id));
+  async updateNodeTree(canvasData: NodeTreeObject, mindmapId: number) {
+    try {
+      const currentNodes = await this.nodeRepository.find({
+        where: { mindmap: { id: mindmapId } },
+        select: ['id'],
+      });
 
-    const updateData = Object.values(canvasData).map((node) => {
-      return {
+      const [nodesToDelete, updateNodeDtos] = this.prepareNodeUpdates(currentNodes, canvasData);
+      await this.executeNodeUpdates(nodesToDelete, updateNodeDtos);
+    } catch (error: any) {
+      const message = `노드 트리 업데이트 중 오류가 발생했습니다: ${error.message || '알 수 없는 오류'}`;
+      this.logger.error(message);
+    }
+  }
+
+  private prepareNodeUpdates(currentNodes: Pick<Node, 'id'>[], canvasData: NodeTreeObject) {
+    const currentNodeIds = currentNodes.map((node) => node.id);
+    const receivedNodeIds = Object.keys(canvasData).map(Number);
+
+    return [
+      this.findNodesToDelete(currentNodeIds, receivedNodeIds),
+      this.convertCanvasDataToUpdateDto(canvasData),
+    ] as const;
+  }
+
+  private async executeNodeUpdates(nodesToDelete: Pick<Node, 'id'>[], updateNodeDtos: UpdateNodeDto[]) {
+    await this.nodeRepository.manager.transaction(async (transactionalEntityManager) => {
+      if (nodesToDelete.length > 0) {
+        await transactionalEntityManager.softRemove(Node, nodesToDelete);
+      }
+
+      if (updateNodeDtos.length > 0) {
+        await Promise.all(updateNodeDtos.map((dto) => transactionalEntityManager.update(Node, dto.id, dto)));
+      }
+    });
+  }
+
+  private findNodesToDelete(currentNodeIds: number[], receivedNodeIds: number[]) {
+    const deleteNodeIds = currentNodeIds.filter((id) => !receivedNodeIds.includes(id));
+    if (deleteNodeIds.length === 0) return [];
+
+    return deleteNodeIds.map((id) => ({ id })) as Pick<Node, 'id'>[];
+  }
+
+  private convertCanvasDataToUpdateDto(canvasData: NodeTreeObject) {
+    return Object.values(canvasData).map(
+      (node) =>
+        ({
         id: node.id,
         keyword: node.keyword,
         locationX: node.location.x,
         locationY: node.location.y,
         depth: node.depth,
-    }));
+        }) as UpdateNodeDto,
+    );
   }
 
   private async findRootNode(mindmapId: number) {

--- a/BE/apps/api-server/src/modules/node/node.service.ts
+++ b/BE/apps/api-server/src/modules/node/node.service.ts
@@ -6,6 +6,11 @@ import { NodeDto } from './dto/node.dto';
 import { UpdateNodeDto } from './dto/update.node.dto';
 import { TextAiResponse } from '../ai/ai.service';
 
+type NodeTreeObject = {
+  [key: number]: NodeDto;
+};
+const ROOT_DEPTH = 1;
+
 @Injectable()
 export class NodeService {
   private readonly logger = new Logger(NodeService.name);
@@ -16,26 +21,24 @@ export class NodeService {
     return nodeList.map((node) => node.keyword);
   }
 
-  async tableToCanvas(mindmapId: number) {
-    const rootNode = await this.nodeRepository.findOne({
-      where: { mindmap: { id: mindmapId }, depth: 1 },
-    });
-
-    if (!rootNode) {
-      return {};
-    }
-
+  async getNodeTreeObject(mindmapId: number) {
+    const rootNode = await this.findRootNode(mindmapId);
+    if (!rootNode) return {};
     const nodeTree = await this.nodeRepository.findDescendants(rootNode, { relations: ['children'] });
+    return nodeTree.reduce((result, node) => {
+      result[node.id] = this.toCanvas(node);
+      return result;
+    }, {} as NodeTreeObject);
+  }
 
-    const nodeTreeArray = nodeTree.map((node) => ({
+  private toCanvas(node: Node): NodeDto {
+    return {
       id: node.id,
       keyword: node.keyword,
       depth: node.depth,
       location: { x: node.locationX, y: node.locationY },
       children: node.children.map((child) => child.id),
-    }));
-
-    return Object.fromEntries(nodeTreeArray.map((node) => [node.id, node]));
+    };
   }
 
   async canvasToTable(canvasData: Record<number, NodeDto>, mindmapId: number) {
@@ -51,12 +54,11 @@ export class NodeService {
         locationX: node.location.x,
         locationY: node.location.y,
         depth: node.depth,
-      } as UpdateNodeDto;
-    });
+    }));
+  }
 
-    await this.deleteNodes(deleteNodeIds);
-    await this.updateNode(updateData);
-    this.logger.log('데이터 저장 끝');
+  private async findRootNode(mindmapId: number) {
+    return this.nodeRepository.findOne({ where: { mindmap: { id: mindmapId }, depth: ROOT_DEPTH } });
   }
 
   async deleteNodes(deleteNodeId: number[] | number) {

--- a/BE/apps/api-server/src/modules/node/node.service.ts
+++ b/BE/apps/api-server/src/modules/node/node.service.ts
@@ -89,11 +89,11 @@ export class NodeService {
     return Object.values(canvasData).map(
       (node) =>
         ({
-        id: node.id,
-        keyword: node.keyword,
-        locationX: node.location.x,
-        locationY: node.location.y,
-        depth: node.depth,
+          id: node.id,
+          keyword: node.keyword,
+          locationX: node.location.x,
+          locationY: node.location.y,
+          depth: node.depth,
         }) as UpdateNodeDto,
     );
   }
@@ -135,14 +135,14 @@ export class NodeService {
     if (existingRoot) {
       existingRoot.keyword = aiResponse.keyword;
       return this.nodeRepository.save(existingRoot);
-        }
+    }
 
     return this.nodeRepository.save({
       keyword: aiResponse.keyword,
       depth: ROOT_DEPTH,
-          mindmap: { id: mindmapId },
-        });
-      }
+      mindmap: { id: mindmapId },
+    });
+  }
 
   private async createChildNode(
     parentNode: Node,

--- a/BE/apps/api-server/src/modules/node/node.service.ts
+++ b/BE/apps/api-server/src/modules/node/node.service.ts
@@ -1,7 +1,7 @@
 import { Node } from '@app/entity';
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { In, TreeRepository } from 'typeorm';
+import { TreeRepository } from 'typeorm';
 import { NodeDto } from './dto/node.dto';
 import { UpdateNodeDto } from './dto/update.node.dto';
 import { TextAiResponse } from '../ai/ai.service';

--- a/BE/apps/api-server/src/modules/subscriber/subscriber.service.ts
+++ b/BE/apps/api-server/src/modules/subscriber/subscriber.service.ts
@@ -90,7 +90,7 @@ export class SubscriberService implements OnModuleInit {
 
     try {
       const parsedNodeData = JSON.parse(nodeData);
-      await this.nodeService.canvasToTable(parsedNodeData, Number(mindmapData.mindmapId));
+      await this.nodeService.updateNodeTree(parsedNodeData, Number(mindmapData.mindmapId));
       await this.mindmapService.update(Number(mindmapData.mindmapId), updateData);
     } catch (error) {
       this.logger.error(`saveData 이벤트 처리 실패: ${error}`);

--- a/BE/apps/api-server/src/modules/user/user.controller.spec.ts
+++ b/BE/apps/api-server/src/modules/user/user.controller.spec.ts
@@ -1,20 +1,38 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
-
+import { User } from '@app/entity';
 describe('UserController', () => {
   let controller: UserController;
+  let userService: UserService;
+
+  const mockUserService = {
+    getUserInfo: jest.fn(),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UserController],
-      providers: [UserService],
+      providers: [{ provide: UserService, useValue: mockUserService }],
     }).compile();
 
     controller = module.get<UserController>(UserController);
+    userService = module.get<UserService>(UserService);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('getUserInfo', () => {
+    it('유저 정보를 조회해야 한다', async () => {
+      const mockUser = { id: 1, email: 'test@example.com', name: 'Test User' };
+      mockUserService.getUserInfo.mockResolvedValue(mockUser);
+
+      const result = await controller.getUserInfo(mockUser);
+
+      expect(result).toEqual(mockUser);
+      expect(mockUserService.getUserInfo).toHaveBeenCalledWith(mockUser.id);
+    });
   });
 });

--- a/BE/apps/api-server/src/modules/user/user.service.spec.ts
+++ b/BE/apps/api-server/src/modules/user/user.service.spec.ts
@@ -51,8 +51,8 @@ describe('UserService', () => {
     expect(userService).toBeDefined();
   });
 
-  describe('createGithubUser', () => {
-    it('github 유저를 생성해야 한다', async () => {
+  describe('createbUser', () => {
+    it('github 유저를 생성한다', async () => {
       const userDto: UserCreateDto = {
         email: 'test@example.com',
         name: 'Test User',
@@ -62,59 +62,14 @@ describe('UserService', () => {
       userRepository.create.mockReturnValue(user);
       userRepository.save.mockResolvedValue(user);
 
-      const result = await userService.createGithubUser(userDto);
+      const result = await userService.createUser(userDto, 'github');
 
       expect(userRepository.create).toHaveBeenCalledWith(user);
       expect(userRepository.save).toHaveBeenCalledWith(user);
       expect(result).toEqual(user);
     });
 
-    it('DTO가 유효하지 않으면 예외가 발생해야 한다 : 이메일이 없는 경우', async () => {
-      const userDto: UserCreateDto = {
-        email: '',
-        name: 'Test User',
-      };
-
-      await expect(userService.createGithubUser(userDto)).rejects.toThrow(BadRequestException);
-      expect(userRepository.create).not.toHaveBeenCalled();
-      expect(userRepository.save).not.toHaveBeenCalled();
-    });
-
-    it('DTO가 유효하지 않으면 예외가 발생해야 한다 : 이름이 없는 경우', async () => {
-      const userDto: UserCreateDto = {
-        email: 'test@example.com',
-        name: '',
-      };
-
-      await expect(userService.createGithubUser(userDto)).rejects.toThrow(BadRequestException);
-      expect(userRepository.create).not.toHaveBeenCalled();
-      expect(userRepository.save).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('findByGithubEmail', () => {
-    it('github 유저를 조회해야 한다', async () => {
-      const email = 'test@example.com';
-      const user = { id: 1, email, name: 'Test User', type: 'github' };
-      userRepository.findOne.mockResolvedValue(user);
-
-      const result = await userService.findByGithubEmail(email);
-
-      expect(userRepository.findOne).toHaveBeenCalledWith({ where: { email, type: 'github' } });
-      expect(result).toEqual(user);
-    });
-
-    it('github 유저를 찾을 수 없으면 null을 반환해야 한다', async () => {
-      const email = 'test@example.com';
-      userRepository.findOne.mockResolvedValue(null);
-
-      const result = await userService.findByGithubEmail(email);
-      expect(result).toBeNull();
-    });
-  });
-
-  describe('createKakaoUser', () => {
-    it('kakao 유저를 생성해야 한다', async () => {
+    it('kakao 유저를 생성한다', async () => {
       const userDto: UserCreateDto = {
         email: 'test@example.com',
         name: 'Test User',
@@ -124,7 +79,7 @@ describe('UserService', () => {
       userRepository.create.mockReturnValue(user);
       userRepository.save.mockResolvedValue(user);
 
-      const result = await userService.createKakaoUser(userDto);
+      const result = await userService.createUser(userDto, 'kakao');
 
       expect(userRepository.create).toHaveBeenCalledWith(user);
       expect(userRepository.save).toHaveBeenCalledWith(user);
@@ -137,7 +92,7 @@ describe('UserService', () => {
         name: 'Test User',
       };
 
-      await expect(userService.createKakaoUser(userDto)).rejects.toThrow(BadRequestException);
+      await expect(userService.createUser(userDto, 'github')).rejects.toThrow(BadRequestException);
       expect(userRepository.create).not.toHaveBeenCalled();
       expect(userRepository.save).not.toHaveBeenCalled();
     });
@@ -148,28 +103,40 @@ describe('UserService', () => {
         name: '',
       };
 
-      await expect(userService.createKakaoUser(userDto)).rejects.toThrow(BadRequestException);
+      await expect(userService.createUser(userDto, 'github')).rejects.toThrow(BadRequestException);
       expect(userRepository.create).not.toHaveBeenCalled();
       expect(userRepository.save).not.toHaveBeenCalled();
     });
   });
-  describe('findByKakaoEmail', () => {
+
+  describe('findByEmail', () => {
+    it('github 유저를 조회해야 한다', async () => {
+      const email = 'test@example.com';
+      const user = { id: 1, email, name: 'Test User', type: 'github' };
+      userRepository.findOne.mockResolvedValue(user);
+
+      const result = await userService.findByEmail(email, 'github');
+
+      expect(userRepository.findOne).toHaveBeenCalledWith({ where: { email, type: 'github' } });
+      expect(result).toEqual(user);
+    });
+
     it('kakao 유저를 조회해야 한다', async () => {
       const email = 'test@example.com';
       const user = { id: 1, email, name: 'Test User', type: 'kakao' };
       userRepository.findOne.mockResolvedValue(user);
 
-      const result = await userService.findByKakaoEmail(email);
+      const result = await userService.findByEmail(email, 'kakao');
 
       expect(userRepository.findOne).toHaveBeenCalledWith({ where: { email, type: 'kakao' } });
       expect(result).toEqual(user);
     });
 
-    it('kakao 유저를 찾을 수 없으면 null을 반환해야 한다', async () => {
+    it('유저를 찾을 수 없으면 null을 반환해야 한다', async () => {
       const email = 'test@example.com';
       userRepository.findOne.mockResolvedValue(null);
 
-      const result = await userService.findByKakaoEmail(email);
+      const result = await userService.findByEmail(email, 'github');
       expect(result).toBeNull();
     });
   });

--- a/BE/apps/api-server/src/modules/user/user.service.spec.ts
+++ b/BE/apps/api-server/src/modules/user/user.service.spec.ts
@@ -51,7 +51,7 @@ describe('UserService', () => {
     expect(userService).toBeDefined();
   });
 
-  describe('createbUser', () => {
+  describe('createUser', () => {
     it('github 유저를 생성한다', async () => {
       const userDto: UserCreateDto = {
         email: 'test@example.com',

--- a/BE/apps/api-server/src/modules/user/user.service.spec.ts
+++ b/BE/apps/api-server/src/modules/user/user.service.spec.ts
@@ -1,18 +1,236 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UserService } from './user.service';
+import { User } from '@app/entity';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { UserMindmapRole } from '@app/entity';
+import { Repository } from 'typeorm';
+import { UserCreateDto } from './dto';
+import { BadRequestException } from '@nestjs/common';
 
+type MockRepository<T> = Partial<Record<keyof Repository<T>, jest.Mock>>;
 describe('UserService', () => {
-  let service: UserService;
+  let userService: UserService;
+  let userRepository: MockRepository<User>;
+  let userMindmapRoleRepository: MockRepository<UserMindmapRole>;
+
+  const mockUserRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findOne: jest.fn(),
+  };
+
+  const mockUserMindmapRoleRepository = {
+    findOne: jest.fn(),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [UserService],
+      providers: [
+        UserService,
+        {
+          provide: getRepositoryToken(User),
+          useValue: mockUserRepository,
+        },
+        {
+          provide: getRepositoryToken(UserMindmapRole),
+          useValue: mockUserMindmapRoleRepository,
+        },
+      ],
     }).compile();
 
-    service = module.get<UserService>(UserService);
+    userService = module.get<UserService>(UserService);
+    userRepository = module.get<MockRepository<User>>(getRepositoryToken(User));
+    userMindmapRoleRepository = module.get<MockRepository<UserMindmapRole>>(getRepositoryToken(UserMindmapRole));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {
-    expect(service).toBeDefined();
+    expect(userService).toBeDefined();
+  });
+
+  describe('createGithubUser', () => {
+    it('github 유저를 생성해야 한다', async () => {
+      const userDto: UserCreateDto = {
+        email: 'test@example.com',
+        name: 'Test User',
+      };
+      const user = { ...userDto, type: 'github' };
+
+      userRepository.create.mockReturnValue(user);
+      userRepository.save.mockResolvedValue(user);
+
+      const result = await userService.createGithubUser(userDto);
+
+      expect(userRepository.create).toHaveBeenCalledWith(user);
+      expect(userRepository.save).toHaveBeenCalledWith(user);
+      expect(result).toEqual(user);
+    });
+
+    it('DTO가 유효하지 않으면 예외가 발생해야 한다 : 이메일이 없는 경우', async () => {
+      const userDto: UserCreateDto = {
+        email: '',
+        name: 'Test User',
+      };
+
+      await expect(userService.createGithubUser(userDto)).rejects.toThrow(BadRequestException);
+      expect(userRepository.create).not.toHaveBeenCalled();
+      expect(userRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('DTO가 유효하지 않으면 예외가 발생해야 한다 : 이름이 없는 경우', async () => {
+      const userDto: UserCreateDto = {
+        email: 'test@example.com',
+        name: '',
+      };
+
+      await expect(userService.createGithubUser(userDto)).rejects.toThrow(BadRequestException);
+      expect(userRepository.create).not.toHaveBeenCalled();
+      expect(userRepository.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('findByGithubEmail', () => {
+    it('github 유저를 조회해야 한다', async () => {
+      const email = 'test@example.com';
+      const user = { id: 1, email, name: 'Test User', type: 'github' };
+      userRepository.findOne.mockResolvedValue(user);
+
+      const result = await userService.findByGithubEmail(email);
+
+      expect(userRepository.findOne).toHaveBeenCalledWith({ where: { email, type: 'github' } });
+      expect(result).toEqual(user);
+    });
+
+    it('github 유저를 찾을 수 없으면 null을 반환해야 한다', async () => {
+      const email = 'test@example.com';
+      userRepository.findOne.mockResolvedValue(null);
+
+      const result = await userService.findByGithubEmail(email);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('createKakaoUser', () => {
+    it('kakao 유저를 생성해야 한다', async () => {
+      const userDto: UserCreateDto = {
+        email: 'test@example.com',
+        name: 'Test User',
+      };
+      const user = { ...userDto, type: 'kakao' };
+
+      userRepository.create.mockReturnValue(user);
+      userRepository.save.mockResolvedValue(user);
+
+      const result = await userService.createKakaoUser(userDto);
+
+      expect(userRepository.create).toHaveBeenCalledWith(user);
+      expect(userRepository.save).toHaveBeenCalledWith(user);
+      expect(result).toEqual(user);
+    });
+
+    it('DTO가 유효하지 않으면 예외가 발생해야 한다 : 이메일이 없는 경우', async () => {
+      const userDto: UserCreateDto = {
+        email: '',
+        name: 'Test User',
+      };
+
+      await expect(userService.createKakaoUser(userDto)).rejects.toThrow(BadRequestException);
+      expect(userRepository.create).not.toHaveBeenCalled();
+      expect(userRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('DTO가 유효하지 않으면 예외가 발생해야 한다 : 이름이 없는 경우', async () => {
+      const userDto: UserCreateDto = {
+        email: 'test@example.com',
+        name: '',
+      };
+
+      await expect(userService.createKakaoUser(userDto)).rejects.toThrow(BadRequestException);
+      expect(userRepository.create).not.toHaveBeenCalled();
+      expect(userRepository.save).not.toHaveBeenCalled();
+    });
+  });
+  describe('findByKakaoEmail', () => {
+    it('kakao 유저를 조회해야 한다', async () => {
+      const email = 'test@example.com';
+      const user = { id: 1, email, name: 'Test User', type: 'kakao' };
+      userRepository.findOne.mockResolvedValue(user);
+
+      const result = await userService.findByKakaoEmail(email);
+
+      expect(userRepository.findOne).toHaveBeenCalledWith({ where: { email, type: 'kakao' } });
+      expect(result).toEqual(user);
+    });
+
+    it('kakao 유저를 찾을 수 없으면 null을 반환해야 한다', async () => {
+      const email = 'test@example.com';
+      userRepository.findOne.mockResolvedValue(null);
+
+      const result = await userService.findByKakaoEmail(email);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('findById', () => {
+    it('유저를 조회해야 한다', async () => {
+      const userId = 1;
+      const user = { id: userId, email: 'test@example.com', name: 'Test User', type: 'github' };
+      userRepository.findOne.mockResolvedValue(user);
+
+      const result = await userService.findById(userId);
+
+      expect(userRepository.findOne).toHaveBeenCalledWith({ where: { id: userId } });
+      expect(result).toEqual(user);
+    });
+
+    it('유저를 찾을 수 없으면 null을 반환해야 한다', async () => {
+      const userId = 1;
+      userRepository.findOne.mockResolvedValue(null);
+
+      const result = await userService.findById(userId);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getUserInfo', () => {
+    it('유저 정보를 조회해야 한다', async () => {
+      const userId = 1;
+      const user = { id: userId, email: 'test@example.com', name: 'Test User' };
+      userRepository.findOne.mockResolvedValue(user);
+
+      const result = await userService.getUserInfo(userId);
+
+      expect(userRepository.findOne).toHaveBeenCalledWith({ where: { id: userId } });
+      expect(result).toEqual(user);
+    });
+  });
+
+  describe('getRole', () => {
+    it('유저 역할을 조회해야 한다', async () => {
+      const userId = 1;
+      const mindmapId = 1;
+      const role = 'admin';
+      const userMindmapRole = { id: 1, user: { id: userId }, mindmap: { id: mindmapId }, role };
+      userMindmapRoleRepository.findOne.mockResolvedValue(userMindmapRole);
+
+      const result = await userService.getRole(userId, mindmapId);
+
+      expect(userMindmapRoleRepository.findOne).toHaveBeenCalledWith({
+        where: { user: { id: userId }, mindmap: { id: mindmapId } },
+      });
+      expect(result).toEqual(role);
+    });
+
+    it('유저 역할을 찾을 수 없으면 null을 반환해야 한다', async () => {
+      const userId = 1;
+      const mindmapId = 1;
+      userMindmapRoleRepository.findOne.mockResolvedValue(null);
+
+      const result = await userService.getRole(userId, mindmapId);
+      expect(result).toBeNull();
+    });
   });
 });

--- a/BE/apps/api-server/src/modules/user/user.service.ts
+++ b/BE/apps/api-server/src/modules/user/user.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User, UserMindmapRole } from '@app/entity';
 import { Repository } from 'typeorm';
@@ -12,6 +12,10 @@ export class UserService {
   ) {}
 
   async createGithubUser(user: UserCreateDto) {
+    if (!user.email || !user.name) {
+      throw new BadRequestException('이메일과 이름은 필수 입력 항목입니다.');
+    }
+
     const createdUser = this.userRepository.create({ email: user.email, name: user.name, type: 'github' });
     return await this.userRepository.save(createdUser);
   }
@@ -21,6 +25,9 @@ export class UserService {
   }
 
   async createKakaoUser(user: UserCreateDto) {
+    if (user.email === '' || user.name === '') {
+      throw new BadRequestException('이메일과 이름은 필수 입력 항목입니다.');
+    }
     const createdUser = this.userRepository.create({ email: user.email, name: user.name, type: 'kakao' });
     return await this.userRepository.save(createdUser);
   }
@@ -48,6 +55,6 @@ export class UserService {
       where: { user: { id: userId }, mindmap: { id: mindmapId } },
     });
 
-    return userMindmapRole?.role;
+    return userMindmapRole?.role ?? null;
   }
 }

--- a/BE/apps/api-server/src/modules/user/user.service.ts
+++ b/BE/apps/api-server/src/modules/user/user.service.ts
@@ -4,6 +4,8 @@ import { User, UserMindmapRole } from '@app/entity';
 import { Repository } from 'typeorm';
 import { UserCreateDto, UserInfoDto } from './dto';
 
+export type UserType = 'github' | 'kakao';
+
 @Injectable()
 export class UserService {
   constructor(
@@ -11,29 +13,16 @@ export class UserService {
     @InjectRepository(UserMindmapRole) private readonly userMindmapRoleRepository: Repository<UserMindmapRole>,
   ) {}
 
-  async createGithubUser(user: UserCreateDto) {
+  async createUser(user: UserCreateDto, type: UserType) {
     if (!user.email || !user.name) {
       throw new BadRequestException('이메일과 이름은 필수 입력 항목입니다.');
     }
-
-    const createdUser = this.userRepository.create({ email: user.email, name: user.name, type: 'github' });
+    const createdUser = this.userRepository.create({ email: user.email, name: user.name, type });
     return await this.userRepository.save(createdUser);
   }
 
-  async findByGithubEmail(email: string) {
-    return await this.userRepository.findOne({ where: { email, type: 'github' } });
-  }
-
-  async createKakaoUser(user: UserCreateDto) {
-    if (user.email === '' || user.name === '') {
-      throw new BadRequestException('이메일과 이름은 필수 입력 항목입니다.');
-    }
-    const createdUser = this.userRepository.create({ email: user.email, name: user.name, type: 'kakao' });
-    return await this.userRepository.save(createdUser);
-  }
-
-  async findByKakaoEmail(email: string) {
-    return await this.userRepository.findOne({ where: { email, type: 'kakao' } });
+  async findByEmail(email: string, type: UserType) {
+    return await this.userRepository.findOne({ where: { email, type } });
   }
 
   async findById(id: number) {

--- a/BE/libs/config/src/redis.config.ts
+++ b/BE/libs/config/src/redis.config.ts
@@ -1,22 +1,25 @@
 import { RedisModuleOptions } from '@liaoliaots/nestjs-redis';
 import { ConfigService } from '@nestjs/config';
 
-export const getRedisConfig = (configService: ConfigService): RedisModuleOptions => ({
-  config: [
-    {
-      namespace: 'subscriber',
-      host: configService.get<string>('REDIS_HOST'),
-      port: configService.get<number>('REDIS_PORT'),
-    },
-    {
-      namespace: 'publisher',
-      host: configService.get<string>('REDIS_HOST'),
-      port: configService.get<number>('REDIS_PORT'),
-    },
-    {
-      namespace: 'general',
-      host: configService.get<string>('REDIS_HOST'),
-      port: configService.get<number>('REDIS_PORT'),
-    },
-  ],
-});
+export const getRedisConfig = (...args: unknown[]): RedisModuleOptions => {
+  const configService = args[0] as ConfigService;
+  return {
+    config: [
+      {
+        namespace: 'subscriber',
+        host: configService.get<string>('REDIS_HOST'),
+        port: configService.get<number>('REDIS_PORT'),
+      },
+      {
+        namespace: 'publisher',
+        host: configService.get<string>('REDIS_HOST'),
+        port: configService.get<number>('REDIS_PORT'),
+      },
+      {
+        namespace: 'general',
+        host: configService.get<string>('REDIS_HOST'),
+        port: configService.get<number>('REDIS_PORT'),
+      },
+    ],
+  };
+};

--- a/BE/libs/jwt/src/index.ts
+++ b/BE/libs/jwt/src/index.ts
@@ -1,2 +1,3 @@
 export * from './optional.jwt.guard';
 export * from './jwt.strategy';
+export * from './types';

--- a/BE/libs/jwt/src/jwt.strategy.ts
+++ b/BE/libs/jwt/src/jwt.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
+import { JwtPayload } from './types';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
@@ -12,7 +13,7 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
     });
   }
 
-  async validate(payload: any) {
+  async validate(payload: JwtPayload) {
     return { id: payload.id, email: payload.email };
   }
 }

--- a/BE/libs/jwt/src/types.ts
+++ b/BE/libs/jwt/src/types.ts
@@ -1,0 +1,9 @@
+export type JwtPayload = {
+  id: number;
+  email: string;
+};
+
+export type RefreshTokenPayload = {
+  id: number;
+  email: string;
+};

--- a/BE/tsconfig.json
+++ b/BE/tsconfig.json
@@ -11,6 +11,7 @@
     "outDir": "./dist",
     "baseUrl": "./",
     "incremental": true,
+    "strict": true,
     "skipLibCheck": true,
     "strictNullChecks": false,
     "noImplicitAny": false,
@@ -18,48 +19,20 @@
     "forceConsistentCasingInFileNames": false,
     "noFallthroughCasesInSwitch": false,
     "paths": {
-      "@app/config": [
-        "libs/config/src"
-      ],
-      "@app/config/*": [
-        "libs/config/src/*"
-      ],
-      "@app/typeorm": [
-        "libs/typeorm/src"
-      ],
-      "@app/typeorm/*": [
-        "libs/typeorm/src/*"
-      ],
-      "@app/logger": [
-        "libs/logger/src"
-      ],
-      "@app/logger/*": [
-        "libs/logger/src/*"
-      ],
-      "@app/entity": [
-        "libs/entity/src"
-      ],
-      "@app/entity/*": [
-        "libs/entity/src/*"
-      ],
-      "@app/interface": [
-        "libs/interface/src"
-      ],
-      "@app/interface/*": [
-        "libs/interface/src/*"
-      ],
-      "@app/jwt": [
-        "libs/jwt/src"
-      ],
-      "@app/jwt/*": [
-        "libs/jwt/src/*"
-      ],
-      "@app/publisher": [
-        "libs/publisher/src"
-      ],
-      "@app/publisher/*": [
-        "libs/publisher/src/*"
-      ]
+      "@app/config": ["libs/config/src"],
+      "@app/config/*": ["libs/config/src/*"],
+      "@app/typeorm": ["libs/typeorm/src"],
+      "@app/typeorm/*": ["libs/typeorm/src/*"],
+      "@app/logger": ["libs/logger/src"],
+      "@app/logger/*": ["libs/logger/src/*"],
+      "@app/entity": ["libs/entity/src"],
+      "@app/entity/*": ["libs/entity/src/*"],
+      "@app/interface": ["libs/interface/src"],
+      "@app/interface/*": ["libs/interface/src/*"],
+      "@app/jwt": ["libs/jwt/src"],
+      "@app/jwt/*": ["libs/jwt/src/*"],
+      "@app/publisher": ["libs/publisher/src"],
+      "@app/publisher/*": ["libs/publisher/src/*"]
     }
   }
 }


### PR DESCRIPTION
## 이슈번호
#1 테스트코드 작성
## 작업 내용

## 코드 리팩토링
### 공통
- strict 모드 활성화
  - RedisModule factory함수 시그니처 변경

### AuthModule
- payload type 정의 jwt모듈 라이브러리러 이동
- verifiedRefreshToken() 메서드 분리
- controller refresh(), logout() 메서드 req 타입 지정
- 오타 수정

### UserModule
- createUser 예외처리 추가
- createUser() 메서드 통합 
- findByEmail() 메서드 통합

### NodeModule
- 메서드 이름 수정
- ROOT_DEPTH 상수처리
- 기존 tableToCanvas() 메서드 로직 중 findRootNode(), toCanvas() 로직 분리
- map() + Object.fromEntries() -> reduce()로 변경
- canvasToTable() 메서드 분리
- 각 메서드 타입 명시
- 에러 로그 추가
- aiCreateNode()에서 재귀함수 로직 분리
- 반환해야할 데이터 타입을 새로 만드는 대신 getNodeTreeObject() 함수 사용하도록 변경

## 테스트 코드 작성
- AuthModule
- UserModule
- NodeModule