### PR TITLE
Refact/code RoleModule 추가 및 연관 모듈 수정

### DIFF
--- a/BE/apps/api-server/src/app.module.ts
+++ b/BE/apps/api-server/src/app.module.ts
@@ -16,6 +16,7 @@ import { DashboardModule } from './modules/dashboard/dashboard.module';
 import { AiModule } from './modules/ai/ai.module';
 import { SubscriberModule } from './modules/subscriber/subscriber.module';
 import { PublisherModule } from '@app/publisher';
+import { RoleModule } from './modules/role/role.module';
 
 @Module({
   imports: [
@@ -52,6 +53,7 @@ import { PublisherModule } from '@app/publisher';
     SubscriberModule,
     PublisherModule,
     AiModule,
+    RoleModule,
   ],
   controllers: [],
   providers: [],

--- a/BE/apps/api-server/src/modules/connection/connection.controller.ts
+++ b/BE/apps/api-server/src/modules/connection/connection.controller.ts
@@ -16,10 +16,10 @@ export class ConnectionController {
 
   @Post()
   @UseGuards(OptionalJwtGuard)
-  async createMindMap(@User() user: UserDto | null) {
+  async createConnection(@User() user: UserDto | null) {
     return user
       ? await this.connectionService.createConnection(user.id)
-      : await this.connectionService.createGuestConnection();
+      : await this.connectionService.createConnection();
   }
 
   @Get()
@@ -30,7 +30,7 @@ export class ConnectionController {
       case 'connection':
         return await this.connectionService.getConnection(id as string, user.id);
       case 'mindmap':
-        return await this.connectionService.setConnection(id as number, user.id);
+        return await this.connectionService.getConnectionInfo(id as number, user.id);
       default:
         throw new BadRequestException('Invalid query type');
     }

--- a/BE/apps/api-server/src/modules/connection/connection.module.ts
+++ b/BE/apps/api-server/src/modules/connection/connection.module.ts
@@ -3,10 +3,10 @@ import { ConnectionController } from './connection.controller';
 import { ConnectionService } from './connection.service';
 import { UserModule } from '../user/user.module';
 import { MindmapModule } from '../mindmap/mindmap.module';
-
+import { RoleModule } from '../role/role.module';
 @Module({
   controllers: [ConnectionController],
-  imports: [UserModule, MindmapModule],
+  imports: [UserModule, MindmapModule, RoleModule],
   providers: [ConnectionService],
 })
 export class ConnectionModule {}

--- a/BE/apps/api-server/src/modules/connection/connection.service.ts
+++ b/BE/apps/api-server/src/modules/connection/connection.service.ts
@@ -1,9 +1,39 @@
 import { MindmapService } from './../mindmap/mindmap.service';
-import { UserService } from './../user/user.service';
 import { ForbiddenException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { Redis } from 'ioredis';
 import { RedisService } from '@liaoliaots/nestjs-redis';
 import { v4 as uuidv4 } from 'uuid';
+import { Role } from '@app/entity/enum/role.enum';
+import { RoleService } from '../role/role.service';
+
+interface BaseConnectionInfo {
+  type: 'guest' | 'user';
+  aiCount: number;
+  title: string;
+}
+
+interface GuestConnectionInfo extends BaseConnectionInfo {
+  type: 'guest';
+}
+
+interface UserConnectionInfo extends BaseConnectionInfo {
+  type: 'user';
+  mindmapId: number;
+  ownerId: number;
+}
+
+interface BaseConnectionResponse {
+  connectionId: string;
+  role: Role;
+}
+
+export interface GuestConnectionResponse extends BaseConnectionResponse {
+  role: Role.OWNER;
+}
+
+export interface UserConnectionResponse extends BaseConnectionResponse {
+  mindmapId: number;
+}
 
 @Injectable()
 export class ConnectionService {
@@ -12,59 +42,97 @@ export class ConnectionService {
 
   constructor(
     private readonly redisService: RedisService,
-    private readonly userService: UserService,
     private readonly mindmapService: MindmapService,
+    private readonly roleService: RoleService,
   ) {
     this.GeneralRedis = this.redisService.getOrThrow('general');
   }
 
-  async createConnection(userId: number) {
+  async createConnection(userId: null | number = null) {
+    if (userId) {
+      return await this.createUserConnection(userId);
+    }
+    return await this.createGuestConnection();
+  }
+
+  private async createUserConnection(userId: number): Promise<UserConnectionResponse> {
     const mindmapId = await this.mindmapService.create(userId);
-    return await this.setConnection(mindmapId, userId);
+    return await this.getConnectionInfo(mindmapId, userId);
   }
 
-  async createGuestConnection() {
+  private async createGuestConnection(): Promise<GuestConnectionResponse> {
     const connectionId = uuidv4();
-    await Promise.all([
-      this.GeneralRedis.hset(connectionId, { type: 'guest', aiCount: 0, title: '제목없음' }),
-      this.GeneralRedis.set(`mindmapState:${connectionId}`, JSON.stringify({})),
-      this.GeneralRedis.set(`content:${connectionId}`, ''),
-    ]);
-    return { connectionId, role: 'owner' };
+    const guestInfo: GuestConnectionInfo = {
+      type: 'guest',
+      aiCount: 0,
+      title: '제목없음',
+    };
+
+    await this.cachingConnectionInfo(connectionId, guestInfo);
+    return { connectionId, role: Role.OWNER };
   }
 
-  async getConnection(connectionId: string, userId: number) {
+  async getConnection(connectionId: string, userId: number): Promise<UserConnectionResponse> {
     const mindmap = await this.mindmapService.getMindmapByConnectionId(connectionId);
     if (!mindmap) {
+      this.logger.error(`Mindmap with connectionId ${connectionId} not found`);
       throw new NotFoundException('마인드맵을 찾을 수 없습니다.');
     }
-    return await this.setConnection(mindmap.id, userId);
+    return await this.getConnectionInfo(mindmap.id, userId);
   }
 
-  async setConnection(mindmapId: number, userId: number) {
-    const role = await this.userService.getRole(userId, mindmapId);
-    this.logger.log(`role: ${role}`);
+  async getConnectionInfo(mindmapId: number, userId: number): Promise<UserConnectionResponse> {
+    const role = await this.roleService.getUserRole(userId, mindmapId);
     if (!role) {
+      this.logger.error(`User ${userId} does not have role for mindmap ${mindmapId}`);
       throw new ForbiddenException('권한이 없습니다.');
     }
 
-    const owner = await this.mindmapService.getOwner(mindmapId);
+    const ownerResult = await this.roleService.getMindmapOwner(mindmapId);
+    if (ownerResult.length === 0) {
+      this.logger.error(`Owner not found for mindmap ${mindmapId} where user ${userId} has role ${role}`);
+      throw new NotFoundException('마인드맵 소유자 정보를 찾을 수 없습니다.');
+    }
+    const ownerInfo = ownerResult[0];
+
     const mindmapData = await this.mindmapService.getDataByMindmapId(mindmapId);
-    await this.GeneralRedis.hset(mindmapData.connectionId, {
+
+    const userInfo: UserConnectionInfo = {
       type: 'user',
-      mindmapId: mindmapId,
+      mindmapId,
       aiCount: mindmapData.aiCount,
       title: mindmapData.title,
-      ownerId: owner.pop().userId,
-    });
+      ownerId: ownerInfo.userId,
+    };
 
-    await this.GeneralRedis.set(`mindmapState:${mindmapData.connectionId}`, JSON.stringify(mindmapData.nodes));
-    await this.GeneralRedis.set(`content:${mindmapData.connectionId}`, mindmapData.content);
+    await this.cachingConnectionInfo(mindmapData.connectionId, userInfo, mindmapData.nodes, mindmapData.content);
 
     return {
       mindmapId,
       connectionId: mindmapData.connectionId,
-      role: role,
+      role,
     };
+  }
+
+  private async cachingConnectionInfo<T extends BaseConnectionInfo>(
+    connectionId: string,
+    info: T,
+    nodes: object = {},
+    content: string = '',
+  ) {
+    if (await this.isCachedConnection(connectionId)) {
+      return;
+    }
+
+    await Promise.all([
+      this.GeneralRedis.hset(connectionId, info),
+      this.GeneralRedis.set(`mindmapState:${connectionId}`, JSON.stringify(nodes)),
+      this.GeneralRedis.set(`content:${connectionId}`, content),
+    ]);
+  }
+
+  private async isCachedConnection(connectionId: string) {
+    const cachedInfo = await this.GeneralRedis.hgetall(connectionId);
+    return Object.keys(cachedInfo).length > 0;
   }
 }

--- a/BE/apps/api-server/src/modules/dashboard/dashboard.module.ts
+++ b/BE/apps/api-server/src/modules/dashboard/dashboard.module.ts
@@ -3,10 +3,10 @@ import { DashboardService } from './dashboard.service';
 import { DashboardController } from './dashboard.controller';
 import { MindmapModule } from '../mindmap/mindmap.module';
 import { NodeModule } from '../node/node.module';
-
+import { RoleModule } from '../role/role.module';
 @Module({
   controllers: [DashboardController],
-  imports: [MindmapModule, NodeModule],
+  imports: [MindmapModule, NodeModule, RoleModule],
   providers: [DashboardService],
 })
 export class DashboardModule {}

--- a/BE/apps/api-server/src/modules/dashboard/dashboard.service.ts
+++ b/BE/apps/api-server/src/modules/dashboard/dashboard.service.ts
@@ -2,13 +2,14 @@ import { NodeService } from './../node/node.service';
 import { MindmapService } from './../mindmap/mindmap.service';
 import { Injectable, Logger } from '@nestjs/common';
 import { DashboardException } from '../../exceptions';
-
+import { RoleService } from '../role/role.service';
 @Injectable()
 export class DashboardService {
   private readonly logger = new Logger(DashboardService.name);
   constructor(
     private readonly mindmapService: MindmapService,
     private readonly nodeService: NodeService,
+    private readonly roleService: RoleService,
   ) {}
 
   async findAll(userId: number) {
@@ -20,7 +21,7 @@ export class DashboardService {
       }
 
       const mindmapIds = mindmapList.map((mindmap) => mindmap.id);
-      const owners = await this.mindmapService.getOwner(mindmapIds);
+      const owners = await this.roleService.getMindmapOwner(mindmapIds);
       const keywords = await Promise.all(mindmapIds.map((id) => this.nodeService.findKeywordByMindmapId(id)));
 
       return mindmapList.map((mindmap, index) => ({

--- a/BE/apps/api-server/src/modules/mindmap/mindmap.module.ts
+++ b/BE/apps/api-server/src/modules/mindmap/mindmap.module.ts
@@ -5,9 +5,9 @@ import { Mindmap } from '@app/entity';
 import { MindmapController } from './mindmap.controller';
 import { NodeModule } from '../node/node.module';
 import { UserMindmapRole } from '@app/entity/user.mindmap.role';
-
+import { RoleModule } from '../role/role.module';
 @Module({
-  imports: [TypeOrmModule.forFeature([Mindmap, UserMindmapRole]), NodeModule],
+  imports: [TypeOrmModule.forFeature([Mindmap, UserMindmapRole]), NodeModule, RoleModule],
   providers: [MindmapService],
   exports: [MindmapService],
   controllers: [MindmapController],

--- a/BE/apps/api-server/src/modules/mindmap/mindmap.service.ts
+++ b/BE/apps/api-server/src/modules/mindmap/mindmap.service.ts
@@ -1,20 +1,20 @@
 import { InjectRepository } from '@nestjs/typeorm';
 import { ForbiddenException, Injectable, Logger, NotFoundException } from '@nestjs/common';
-import { In, Repository } from 'typeorm';
-import { Mindmap, UserMindmapRole } from '@app/entity';
+import { Repository } from 'typeorm';
+import { Mindmap } from '@app/entity';
 import { v4 as uuidv4 } from 'uuid';
 import { UpdateMindmapDto } from './dto/update.mindmap.dto';
-import { Role } from '@app/entity/enum/role.enum';
 import { NodeService } from '../node/node.service';
 import { MindmapException } from '../../exceptions';
+import { RoleService } from '../role/role.service';
 
 @Injectable()
 export class MindmapService {
   private readonly logger = new Logger(MindmapService.name);
   constructor(
     @InjectRepository(Mindmap) private mindmapRepository: Repository<Mindmap>,
-    @InjectRepository(UserMindmapRole) private userMindmapRoleRepository: Repository<UserMindmapRole>,
     private nodeService: NodeService,
+    private roleService: RoleService,
   ) {}
 
   async create(userId: number) {
@@ -22,7 +22,7 @@ export class MindmapService {
       const uuid = uuidv4();
       const mindmap = this.mindmapRepository.create({ connectionId: uuid, aiContent: '', content: '' });
       const savedMindmap = await this.mindmapRepository.save(mindmap);
-      await this.assignUserToMindmap(userId, savedMindmap.id);
+      await this.roleService.assignRole(userId, savedMindmap.id);
       return savedMindmap.id;
     } catch (error) {
       this.logger.error(error);
@@ -35,39 +35,11 @@ export class MindmapService {
     return uuid;
   }
 
-  async assignUserToMindmap(userId: number, mindmapId: number, role: Role = Role.OWNER) {
-    const existingRole = await this.userMindmapRoleRepository.findOne({
-      where: {
-        user: { id: userId },
-        mindmap: { id: mindmapId },
-      },
-    });
-
-    if (existingRole) {
-      return existingRole;
-    }
-
-    const userMindmapRole = this.userMindmapRoleRepository.create({
-      user: { id: userId },
-      mindmap: { id: mindmapId },
-      role,
-    });
-
-    return await this.userMindmapRoleRepository.save(userMindmapRole);
-  }
-
   async findAllByUserId(userId: number) {
-    const myRoles = await this.userMindmapRoleRepository.find({
-      where: { user: { id: userId } },
-      relations: ['mindmap'],
-      select: ['mindmap'],
+    const mindmaps = await this.mindmapRepository.find({
+      where: { userMindmapRoles: { user: { id: userId } } },
     });
-
-    if (!myRoles) {
-      return [];
-    }
-
-    return myRoles.map((record) => record.mindmap);
+    return mindmaps;
   }
 
   async update(mindmapId: number, updateMindmapDto: UpdateMindmapDto) {
@@ -75,11 +47,8 @@ export class MindmapService {
   }
 
   async delete(mindmapId: number, userId: number) {
-    const role = await this.userMindmapRoleRepository.findOne({
-      where: { user: { id: userId }, mindmap: { id: mindmapId } },
-    });
-
-    if (role.role !== Role.OWNER) {
+    const isOwner = await this.roleService.verifyUserIsOwner(userId, mindmapId);
+    if (!isOwner) {
       throw new ForbiddenException('권한이 없습니다.');
     }
 
@@ -97,11 +66,11 @@ export class MindmapService {
 
   async getDataByMindmapId(mindmapId: number) {
     const mindmap = await this.mindmapRepository.findOne({ where: { id: mindmapId } });
-    const nodes = await this.nodeService.getNodeTreeObject(mindmap.id);
-
     if (!mindmap) {
       throw new NotFoundException('마인드맵을 찾을 수 없습니다.');
     }
+
+    const nodes = await this.nodeService.getNodeTreeObject(mindmap.id);
 
     return {
       title: mindmap.title,
@@ -112,34 +81,7 @@ export class MindmapService {
     };
   }
 
-  async getOwner(mindmapId: number | number[]) {
-    if (Array.isArray(mindmapId)) {
-      const owners = await this.userMindmapRoleRepository.find({
-        where: { mindmap: { id: In(mindmapId) }, role: Role.OWNER },
-        relations: ['user', 'mindmap'],
-      });
-      return owners.map((owner) => {
-        return {
-          mindmapId: owner.mindmap.id,
-          userId: owner.user.id,
-          ownerName: owner.user.name,
-        };
-      });
-    }
-    const owner = await this.userMindmapRoleRepository.findOne({
-      where: { mindmap: { id: mindmapId }, role: Role.OWNER },
-      relations: ['user', 'mindmap'],
-    });
-    return [
-      {
-        mindmapId: owner.mindmap.id,
-        userId: owner.user.id,
-        ownerName: owner.user.name,
-      },
-    ];
-  }
-
-  async getMindmapByConnectionId(connectionId: string) {
+  async getMindmapByConnectionId(connectionId: string): Promise<Mindmap | null> {
     return await this.mindmapRepository.findOne({ where: { connectionId } });
   }
 }

--- a/BE/apps/api-server/src/modules/role/role.module.ts
+++ b/BE/apps/api-server/src/modules/role/role.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { RoleService } from './role.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UserMindmapRole } from '@app/entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([UserMindmapRole])],
+  providers: [RoleService],
+  exports: [RoleService],
+})
+export class RoleModule {}

--- a/BE/apps/api-server/src/modules/role/role.service.spec.ts
+++ b/BE/apps/api-server/src/modules/role/role.service.spec.ts
@@ -1,0 +1,118 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RoleService } from './role.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { UserMindmapRole } from '@app/entity';
+import { Repository } from 'typeorm';
+import { Role } from '@app/entity/enum/role.enum';
+
+describe('RoleService', () => {
+  let service: RoleService;
+  let repository: Repository<UserMindmapRole>;
+
+  const mockUserMindmapRole = {
+    id: 1,
+    user: { id: 1, name: '테스트 유저' },
+    mindmap: { id: 1 },
+    role: Role.OWNER,
+  };
+
+  const mockRepository = {
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RoleService,
+        {
+          provide: getRepositoryToken(UserMindmapRole),
+          useValue: mockRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<RoleService>(RoleService);
+    repository = module.get<Repository<UserMindmapRole>>(getRepositoryToken(UserMindmapRole));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getUserRole', () => {
+    it('사용자의 마인드맵 역할을 반환해야 한다', async () => {
+      mockRepository.findOne.mockResolvedValue(mockUserMindmapRole);
+
+      const result = await service.getUserRole(1, 1);
+      expect(result).toBe(Role.OWNER);
+    });
+
+    it('역할이 없는 경우 null을 반환해야 한다', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.getUserRole(1, 1);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('assignRole', () => {
+    it('새로운 역할을 할당해야 한다', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+      mockRepository.create.mockReturnValue(mockUserMindmapRole);
+      mockRepository.save.mockResolvedValue(mockUserMindmapRole);
+
+      const result = await service.assignRole(1, 1, Role.OWNER);
+      expect(result).toEqual(mockUserMindmapRole);
+    });
+
+    it('기존 역할을 업데이트해야 한다', async () => {
+      const existingRole = { ...mockUserMindmapRole, role: Role.EDITOR };
+      mockRepository.findOne.mockResolvedValue(existingRole);
+      mockRepository.save.mockResolvedValue({ ...existingRole, role: Role.OWNER });
+
+      const result = await service.assignRole(1, 1, Role.OWNER);
+      expect(result.role).toBe(Role.OWNER);
+    });
+  });
+
+  describe('getMindmapOwner', () => {
+    const ownerInfo = {
+      mindmapId: 1,
+      userId: 1,
+      ownerName: '테스트 유저',
+    };
+
+    it('단일 마인드맵의 소유자 정보를 반환해야 한다', async () => {
+      mockRepository.findOne.mockResolvedValue(mockUserMindmapRole);
+
+      const result = await service.getMindmapOwner(1);
+      expect(result).toEqual([ownerInfo]);
+    });
+
+    it('여러 마인드맵의 소유자 정보를 반환해야 한다', async () => {
+      mockRepository.find.mockResolvedValue([mockUserMindmapRole]);
+
+      const result = await service.getMindmapOwner([1]);
+      expect(result).toEqual([ownerInfo]);
+    });
+  });
+
+  describe('verifyUserIsOwner', () => {
+    it('사용자가 소유자인 경우 true를 반환해야 한다', async () => {
+      mockRepository.findOne.mockResolvedValue(mockUserMindmapRole);
+
+      const result = await service.verifyUserIsOwner(1, 1);
+      expect(result).toBe(true);
+    });
+
+    it('사용자가 소유자가 아닌 경우 false를 반환해야 한다', async () => {
+      mockRepository.findOne.mockResolvedValue({ ...mockUserMindmapRole, role: Role.EDITOR });
+
+      const result = await service.verifyUserIsOwner(1, 1);
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/BE/apps/api-server/src/modules/role/role.service.ts
+++ b/BE/apps/api-server/src/modules/role/role.service.ts
@@ -1,0 +1,82 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { UserMindmapRole } from '@app/entity';
+import { In, Repository } from 'typeorm';
+import { Role } from '@app/entity/enum/role.enum';
+
+interface OwnerInfo {
+  mindmapId: number;
+  userId: number;
+  ownerName: string;
+}
+
+@Injectable()
+export class RoleService {
+  constructor(
+    @InjectRepository(UserMindmapRole)
+    private readonly userMindmapRoleRepository: Repository<UserMindmapRole>,
+  ) {}
+
+  async getUserRole(userId: number, mindmapId: number): Promise<Role | null> {
+    const userMindmapRole = await this.userMindmapRoleRepository.findOne({
+      where: { user: { id: userId }, mindmap: { id: mindmapId } },
+    });
+    return userMindmapRole?.role ?? null;
+  }
+
+  async assignRole(userId: number, mindmapId: number, role: Role = Role.OWNER): Promise<UserMindmapRole> {
+    const existingRole = await this.userMindmapRoleRepository.findOne({
+      where: {
+        user: { id: userId },
+        mindmap: { id: mindmapId },
+      },
+    });
+
+    if (existingRole) {
+      if (existingRole.role !== role) {
+        existingRole.role = role;
+        return await this.userMindmapRoleRepository.save(existingRole);
+      }
+      return existingRole;
+    }
+
+    const userMindmapRole = this.userMindmapRoleRepository.create({
+      user: { id: userId },
+      mindmap: { id: mindmapId },
+      role,
+    });
+
+    return await this.userMindmapRoleRepository.save(userMindmapRole);
+  }
+
+  async getMindmapOwner(mindmapIdOrIds: number | number[]): Promise<OwnerInfo[]> {
+    return typeof mindmapIdOrIds === 'number'
+      ? await this.getMindmapOwnerByMindmapId(mindmapIdOrIds)
+      : await this.getAllMindmapOwner(mindmapIdOrIds);
+  }
+
+  private async getAllMindmapOwner(mindmapIds: number[]): Promise<OwnerInfo[]> {
+    const owners = await this.userMindmapRoleRepository.find({
+      where: { mindmap: { id: In(mindmapIds) }, role: Role.OWNER },
+      relations: ['user', 'mindmap'],
+    });
+    return owners.map((owner) => ({
+      mindmapId: owner.mindmap.id,
+      userId: owner.user.id,
+      ownerName: owner.user.name,
+    }));
+  }
+
+  private async getMindmapOwnerByMindmapId(mindmapId: number): Promise<OwnerInfo[]> {
+    const owner = await this.userMindmapRoleRepository.findOne({
+      where: { mindmap: { id: mindmapId }, role: Role.OWNER },
+      relations: ['user', 'mindmap'],
+    });
+    return owner ? [{ mindmapId: owner.mindmap.id, userId: owner.user.id, ownerName: owner.user.name }] : [];
+  }
+
+  async verifyUserIsOwner(userId: number, mindmapId: number): Promise<boolean> {
+    const role = await this.getUserRole(userId, mindmapId);
+    return role === Role.OWNER;
+  }
+}

--- a/BE/apps/api-server/src/modules/user/user.service.spec.ts
+++ b/BE/apps/api-server/src/modules/user/user.service.spec.ts
@@ -2,7 +2,6 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { UserService } from './user.service';
 import { User } from '@app/entity';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { UserMindmapRole } from '@app/entity';
 import { Repository } from 'typeorm';
 import { UserCreateDto } from './dto';
 import { BadRequestException } from '@nestjs/common';
@@ -11,15 +10,10 @@ type MockRepository<T> = Partial<Record<keyof Repository<T>, jest.Mock>>;
 describe('UserService', () => {
   let userService: UserService;
   let userRepository: MockRepository<User>;
-  let userMindmapRoleRepository: MockRepository<UserMindmapRole>;
 
   const mockUserRepository = {
     create: jest.fn(),
     save: jest.fn(),
-    findOne: jest.fn(),
-  };
-
-  const mockUserMindmapRoleRepository = {
     findOne: jest.fn(),
   };
 
@@ -31,16 +25,11 @@ describe('UserService', () => {
           provide: getRepositoryToken(User),
           useValue: mockUserRepository,
         },
-        {
-          provide: getRepositoryToken(UserMindmapRole),
-          useValue: mockUserMindmapRoleRepository,
-        },
       ],
     }).compile();
 
     userService = module.get<UserService>(UserService);
     userRepository = module.get<MockRepository<User>>(getRepositoryToken(User));
-    userMindmapRoleRepository = module.get<MockRepository<UserMindmapRole>>(getRepositoryToken(UserMindmapRole));
   });
 
   afterEach(() => {
@@ -171,33 +160,10 @@ describe('UserService', () => {
       const result = await userService.getUserInfo(userId);
 
       expect(userRepository.findOne).toHaveBeenCalledWith({ where: { id: userId } });
-      expect(result).toEqual(user);
-    });
-  });
-
-  describe('getRole', () => {
-    it('유저 역할을 조회해야 한다', async () => {
-      const userId = 1;
-      const mindmapId = 1;
-      const role = 'admin';
-      const userMindmapRole = { id: 1, user: { id: userId }, mindmap: { id: mindmapId }, role };
-      userMindmapRoleRepository.findOne.mockResolvedValue(userMindmapRole);
-
-      const result = await userService.getRole(userId, mindmapId);
-
-      expect(userMindmapRoleRepository.findOne).toHaveBeenCalledWith({
-        where: { user: { id: userId }, mindmap: { id: mindmapId } },
+      expect(result).toEqual({
+        name: user.name,
+        email: user.email,
       });
-      expect(result).toEqual(role);
-    });
-
-    it('유저 역할을 찾을 수 없으면 null을 반환해야 한다', async () => {
-      const userId = 1;
-      const mindmapId = 1;
-      userMindmapRoleRepository.findOne.mockResolvedValue(null);
-
-      const result = await userService.getRole(userId, mindmapId);
-      expect(result).toBeNull();
     });
   });
 });

--- a/BE/apps/api-server/src/modules/user/user.service.ts
+++ b/BE/apps/api-server/src/modules/user/user.service.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { User, UserMindmapRole } from '@app/entity';
+import { User } from '@app/entity';
 import { Repository } from 'typeorm';
 import { UserCreateDto, UserInfoDto } from './dto';
 
@@ -8,10 +8,7 @@ export type UserType = 'github' | 'kakao';
 
 @Injectable()
 export class UserService {
-  constructor(
-    @InjectRepository(User) private readonly userRepository: Repository<User>,
-    @InjectRepository(UserMindmapRole) private readonly userMindmapRoleRepository: Repository<UserMindmapRole>,
-  ) {}
+  constructor(@InjectRepository(User) private readonly userRepository: Repository<User>) {}
 
   async createUser(user: UserCreateDto, type: UserType) {
     if (!user.email || !user.name) {
@@ -31,19 +28,9 @@ export class UserService {
 
   async getUserInfo(userId: number) {
     const user = await this.userRepository.findOne({ where: { id: userId } });
-
     return {
-      id: user.id,
       name: user.name,
       email: user.email,
     } as UserInfoDto;
-  }
-
-  async getRole(userId: number, mindmapId: number) {
-    const userMindmapRole = await this.userMindmapRoleRepository.findOne({
-      where: { user: { id: userId }, mindmap: { id: mindmapId } },
-    });
-
-    return userMindmapRole?.role ?? null;
   }
 }


### PR DESCRIPTION
## 작업 내용
### RoleModule 추가
- 기존 Role관련 조회 메서드가 userService, mindmapService 둘 다 있어서 RoleModule로 통합

### ConnectionModule 수정
- 컨트롤러에 createMindMap() -> createConnection() 으로 이름 변경
- redis 캐싱 로직 분리
- redis 캐싱 전 캐싱된 데이터가 있는지 확인하는 로직 추가
